### PR TITLE
Bump python from 3.9.2 to 3.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.2
+FROM python:3.10.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps python from 3.9.2 to 3.10.0.

---
updated-dependencies:
- dependency-name: python
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>