### PR TITLE
Chore: Delete `aiohttp` 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,9 @@ setuptools.setup(
         "Intended Audience :: Customer Service",
         "Development Status :: 4 - Beta",
         "Natural Language :: English",
-        "Framework :: aiohttp",
+        # Waiting For this PR to Merged for adding FastAPI
+        # https://github.com/pypa/trove-classifiers/pull/80
+        # "Framework :: FastAPI",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Waiting for https://github.com/pypa/trove-classifiers to add `Framework :: FastAPI` 