### PR TITLE
chore: add FastAPI to Classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,7 @@ setuptools.setup(
         "Intended Audience :: Customer Service",
         "Development Status :: 4 - Beta",
         "Natural Language :: English",
-        # Waiting For this PR to Merged for adding FastAPI
-        # https://github.com/pypa/trove-classifiers/pull/80
-        # "Framework :: FastAPI",
+        "Framework :: FastAPI",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
After @tiangolo opened the PR https://github.com/pypa/trove-classifiers/pull/80 relate to adding FastAPI as a new trove classifier, that's gonna help to add it in our setup file. thanks to @mristin for requesting to add it https://github.com/pypa/trove-classifiers/issues/63 as a Framework. 🚀 

the release commit:
https://github.com/pypa/trove-classifiers/commit/4e2248b1fce527e3943358037a1d5db8e8186fd5