### PR TITLE
Remove unnecessary calls to `enumerate` when the index variable is not used.

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -191,7 +191,7 @@ class MockDatabaseBackend:
         Returns:
             bool: True if the email was confirmed, False otherwise.
         """
-        for i, item in enumerate(self._email_confirmations):
+        for item in self._email_confirmations:
             if item.get("token") == token_hash:
                 user = self._get("email", item.get("email"))
                 await self.update(user.get("id"), {"confirmed": True})


### PR DESCRIPTION
Enumerating iterables with `enumerate` is a good practice for having access to both the values and their respective indices. However, when the indices are not necessary, it is cleaner to simply iterate over the original iterable and remove the call to `enumerate`.