### PR TITLE
chore(Dev): Configure Mypy and Setup Static Typing Checker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Lint
         if: ${{ matrix.python-version != '3.9' }}
         run: pre-commit run --all-files
+      - name: Check Optional static typing
+        if: ${{ matrix.python-version != '3.9' }}
+        run: bash scripts/lint.sh
       - name: Test
         run: bash scripts/test.sh
       - name: Upload coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       rev: 4.0.1
       hooks:
           - id: flake8
-            additional_dependencies: [flake8-print]
+            additional_dependencies: [flake8-print,flake8-bugbear]
             files: '\.py$'
             exclude: docs/
             args:
@@ -37,3 +37,9 @@ repos:
       hooks:
           - id: black
             args: ["--target-version", "py38"]
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.7.0
+      hooks:
+        - id: bandit
+          args: ["-ll"]
+          files: .py$

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,4 @@ clean-test:
 	rm -f .coverage
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
+	rm -fr .mypy_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ requires = [
 [tool.flit.metadata.requires-extra]
 lint = [
     "pre-commit==2.16.0",
+    "mypy==0.931",
 ]
 test = [
     "pytest==6.2.5",
@@ -78,6 +79,26 @@ oauth2 = [
 redis = [
     "aioredis >=2.0.1,<2.1.0",
 ]
+
+[tool.mypy]
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+implicit_reexport = false
+strict_equality = true
+
+[[tool.mypy.overrides]]
+module = "authx.tests.*"
+ignore_missing_imports = true
+check_untyped_defs = true
 
 [tool.flit.metadata.urls]
 Documentation = "https://authx.yezz.codes/"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+mypy authx


### PR DESCRIPTION
Mypy is a static type checker for Python 3 and Python 2.7. If you sprinkle your code with type annotations, mypy can type check your code and find common bugs. As mypy is a static analyzer or a lint-like tool, the type annotations are just hints for mypy and don’t interfere when running your program. You run your program with a standard Python interpreter, and the annotations are treated effectively as comments.