### PR TITLE
chore(feat): support SocketIO in authx  ✨ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Add a Fully registration and authentication or authorization system to your [Fas
 - [x] Full OpenAPI schema support, even with several authentication backend.
 - [x] Provide a Docstring for each class and function.
 - [x] Support Sessions and Pre-built CRUD functions and Instance to launch Redis.
+- [x] Support SocketIO.
 
 **Note:** Check [Release Notes](https://authx.yezz.me/release/).
 

--- a/authx/__init__.py
+++ b/authx/__init__.py
@@ -4,6 +4,7 @@ __version__ = "0.4.0"
 
 from authx.backend import UsersRepo as UsersRepo
 from authx.cache import RedisBackend as RedisBackend
+from authx.core import AuthXSocket as AuthXSocket
 from authx.core import EmailClient as EmailClient
 from authx.core import JWTBackend as JWTBackend
 from authx.core import User as User

--- a/authx/core/__init__.py
+++ b/authx/core/__init__.py
@@ -8,6 +8,7 @@ from authx.core.session import (
     getSessionStorage,
     setSession,
 )
+from authx.core.socket import Socket as AuthXSocket
 from authx.core.user import User
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "getSessionId",
     "getSessionStorage",
     "setSession",
+    "AuthXSocket",
 ]

--- a/authx/core/socket.py
+++ b/authx/core/socket.py
@@ -1,0 +1,87 @@
+from typing import Union
+
+import socketio
+from fastapi import FastAPI
+
+
+class Socket:
+    def __init__(
+        self,
+        app: FastAPI,
+        mount_location: str = "/ws",
+        socketio_path: str = "socket.io",
+        cors_allowed_origins: Union[str, list] = "*",
+        async_mode: str = "asgi",
+    ) -> None:
+        self._socket = socketio.AsyncServer(
+            async_mode=async_mode, cors_allowed_origins=cors_allowed_origins
+        )
+        self._app = socketio.ASGIApp(
+            socketio_server=self._socket, socketio_path=socketio_path
+        )
+
+        app.mount(mount_location, self._app)
+        app.sio = self._socket
+
+    def is_asyncio_based(self) -> bool:
+        return True
+
+    @property
+    def on(self):
+        return self._socket.on
+
+    @property
+    def attach(self):
+        return self._socket.attach
+
+    @property
+    def emit(self):
+        return self._socket.emit
+
+    @property
+    def send(self):
+        return self._socket.send
+
+    @property
+    def call(self):
+        return self._socket.call
+
+    @property
+    def close_room(self):
+        return self._socket.close_room
+
+    @property
+    def get_session(self):
+        return self._socket.get_session
+
+    @property
+    def save_session(self):
+        return self._socket.save_session
+
+    @property
+    def session(self):
+        return self._socket.session
+
+    @property
+    def disconnect(self):
+        return self._socket.disconnect
+
+    @property
+    def handle_request(self):
+        return self._socket.handle_request
+
+    @property
+    def start_background_task(self):
+        return self._socket.start_background_task
+
+    @property
+    def sleep(self):
+        return self._socket.sleep
+
+    @property
+    def enter_room(self):
+        return self._socket.enter_room
+
+    @property
+    def leave_room(self):
+        return self._socket.leave_room

--- a/authx/core/socket.py
+++ b/authx/core/socket.py
@@ -2,6 +2,7 @@ from typing import Union
 
 import socketio
 from fastapi import FastAPI
+from socketio.asyncio_manager import AsyncManager
 
 
 class Socket:
@@ -12,9 +13,12 @@ class Socket:
         socketio_path: str = "socket.io",
         cors_allowed_origins: Union[str, list] = "*",
         async_mode: str = "asgi",
+        client_manager=None,
     ) -> None:
         self._socket = socketio.AsyncServer(
-            async_mode=async_mode, cors_allowed_origins=cors_allowed_origins
+            async_mode=async_mode,
+            cors_allowed_origins=cors_allowed_origins,
+            client_manager=client_manager,
         )
         self._app = socketio.ASGIApp(
             socketio_server=self._socket, socketio_path=socketio_path
@@ -85,3 +89,7 @@ class Socket:
     @property
     def leave_room(self):
         return self._socket.leave_room
+
+    @property
+    def rooms(self):
+        return self._socket.rooms

--- a/docs/configuration/Get-Started.md
+++ b/docs/configuration/Get-Started.md
@@ -49,3 +49,9 @@ AuthX object is the main class from which you'll be able to generate routers for
 Supporting OAuth2 is one of the most important feature of AuthX. We provide a middleware to handle the OAuth2 flow for both FastAPI app and Starlette app that could help you to integrate AuthX with your existing app.
 
 ➡️ [Middleware](middleware/index.md)
+
+## SocketIO
+
+AuthX provides a Socket.IO server that can be used to communicate with your API.
+
+➡️ [SocketIO](socket/index.md)

--- a/docs/configuration/socket/index.md
+++ b/docs/configuration/socket/index.md
@@ -1,0 +1,61 @@
+# Socket
+
+Socket.IO was created in 2010. It was developed to use open connections to facilitate realtime communication, still a relatively new phenomenon at the time.
+
+Socket.IO allows bi-directional communication between client and server. Bi-directional communications are enabled when a client has Socket.IO in the browser, and a server has also integrated the Socket.IO package. While data can be sent in a number of forms, JSON is the simplest.
+
+To establish the connection, and to exchange data between client and server, Socket.IO uses Engine.IO. This is a lower-level implementation used under the hood. Engine.IO is used for the server implementation and Engine.IO-client is used for the client.
+
+![socket](https://images.ctfassets.net/ee3ypdtck0rk/1Lj7lbqX54WCiHI2uVVL3x/a7f857e10d3c1e93b4349639c04318bc/websocket.io-1b_2x.png?w=1841&h=690&q=50&fm=webp)
+
+## Usage
+
+To add SocketIO support to FastAPI all you need to do is import `AuthXSocket` and pass it `FastAPI` object.
+
+```python
+from fastapi import FastAPI
+from authx import AuthXSocket
+
+app = FastAPI()
+socket = AuthXSocket(app=app)
+```
+
+you can import `AuthXSocket` object that exposes most of the SocketIO functionality.
+
+```python
+@AuthXSocket.on('leave')
+async def handle_leave(sid, *args, **kwargs):
+    await AuthXSocket.emit('lobby', 'User left')
+```
+
+## Working with distributed applications
+
+When working with distributed applications, it is often necessary to access the functionality of the Socket.IO from multiple processes. As a solution to the above problems, the Socket.IO server can be configured to connect to a message queue such as `Redis` or `RabbitMQ`, to communicate with other related Socket.IO servers or auxiliary workers.
+
+Refer this link for more details [using-a-message-queue](https://python-socketio.readthedocs.io/en/latest/server.html#using-a-message-queue)
+
+```python
+
+import socketio
+from fastapi import FastAPI
+from authx import AuthXSocket
+
+app = FastAPI()
+
+redis_manager = socketio.AsyncRedisManager('redis://')
+
+socket_manager = AuthXSocket(app=app, client_manager=redis_manager)
+```
+
+### Emitting from external process
+
+```python
+
+import socketio
+
+# connect to the redis queue as an external process
+external_sio = socketio.RedisManager('redis://', write_only=True)
+
+# emit an event
+external_sio.emit('my event', data={'foo': 'bar'}, room='my room')
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Authx is a fast, flexible and easy to use authentication and authorization libra
 - [x] Extensible base user model.
 - [x] Ready-to-use register, login, reset password and verify e-mail routes.
 - [x] Ready-to-use Social login and Oauth2 routes.
-    - [X] Full Configuration and customization.
+    - [x] Full Configuration and customization.
     - [x] Ready-to-use social OAuth2 login flow.
 - [x] Middleware Support for Oauth2 using `Authlib` and Starlette.
 - [x] Dependency callable to inject current user in route.
@@ -53,7 +53,8 @@ Authx is a fast, flexible and easy to use authentication and authorization libra
     - [x] Cookie authentication backend included
 - [x] Full OpenAPI schema support, even with several authentication backend.
 - [x] Provide a Docstring for each class and function.
-- [X] Support Sessions and Pre-built CRUD functions and Instance to launch Redis.
+- [x] Support Sessions and Pre-built CRUD functions and Instance to launch Redis.
+- [x] Support SocketIO.
 
 ## Project using
 

--- a/example/socket/Makefile
+++ b/example/socket/Makefile
@@ -1,0 +1,13 @@
+PYTHON ?= python3
+VENV ?= venv
+PY ?= $(VENV)/bin/python
+PIP ?= $(VENV)/bin/pip
+EXTRA_FLAGS ?= ''
+BIN ?= $(VENV)/bin
+
+
+run: venv
+	${BIN}/uvicorn --factory app:get_app --host=0.0.0.0 --port=8000
+
+test_client: venv
+	${BIN}/python test_client.py

--- a/example/socket/app.py
+++ b/example/socket/app.py
@@ -1,0 +1,65 @@
+import asyncio
+import json
+from contextlib import suppress
+
+import aiodocker
+from fastapi import FastAPI
+
+from authx import AuthXSocket
+
+
+class GlobalSub:
+    def __init__(self):
+        self.subscribers = {}
+
+    async def emit(self, event):
+        for handler in self.subscribers.values():
+            with suppress(Exception):
+                await handler("docker_event", json.dumps(event))
+
+    def sub(self, sid, handler):
+        self.subscribers[sid] = handler
+
+    def unsub(self, sid):
+        del self.subscribers[sid]
+
+
+def bind_sio(app, registry):
+    @app.sio.on("connect")
+    async def handle_connect(sid, *args, **kwargs):
+        registry.sub(sid, app.sio.emit)
+
+    @app.sio.on("disconnect")
+    async def handle_disconnect(sid):
+        registry.unsub(sid)
+
+
+async def listen(registry, docker):
+    sub = docker.events.subscribe()
+    while True:
+        event = await sub.get()
+        if not event:
+            break
+        event.pop("time")
+        await registry.emit(event)
+
+
+def print_routes(smth):
+    if hasattr(smth, "routes"):
+        for route in getattr(smth, "routes"):
+            print_routes(route)
+        if hasattr(smth, "path"):
+            print(f"NR: {smth.path} => {smth.routes}")
+    else:
+        print(f"Route: {smth.path}")
+
+
+def get_app():
+    registry = GlobalSub()
+    docker = aiodocker.Docker()
+    asyncio.create_task(listen(registry, docker))
+    app = FastAPI()
+    manager = AuthXSocket(app=app, mount_location="/")
+    bind_sio(app, registry)
+    print_routes(app)
+    return app

--- a/example/socket/client.py
+++ b/example/socket/client.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import socketio
+
+sio = socketio.AsyncClient()
+
+
+@sio.event
+async def connect():
+    print("connected to server")
+
+
+@sio.event
+async def disconnect():
+    print("disconnected from server")
+
+
+@sio.event
+def docker_event(event):
+    print(f"Got docker_event: {event}")
+
+
+async def start_server():
+    await sio.connect("http://localhost:8009/")
+    await sio.wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(start_server())

--- a/example/socket/requirements.txt
+++ b/example/socket/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+authx
+docker
+aiodocker
+uvicorn

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,8 @@ nav:
     - Middleware:
       - Introduction: configuration/middleware/index.md
       - configuration/middleware/example.md
+    - Socket:
+      - Introduction: configuration/socket/index.md
   - Help AuthX - Get Help: help.md
   - Development - Contributing: contributing.md
   - Frequently Asked Questions: faq.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,8 @@ requires = [
     "aioredis >=2.0.1,<2.1.0",
     "redis==4.3.3",
     "pytz==2022.1",
-    "python-dateutil==2.8.2"
+    "python-dateutil==2.8.2",
+    "python-socketio>=4.6.0"
 ]
 
 [tool.flit.metadata.requires-extra]


### PR DESCRIPTION
adding SocketIO support to AuthX Manager is easy, all you need to do is `from authx import AuthXSocket` and pass it FastAPI object.

```py
from fastapi import FastAPI
from authx import AuthXSocket

app = FastAPI()
socket = AuthXSocket(app=app)
```