### PR TITLE
:construction_worker: chore(dev): Support middleware for Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ customizable and adaptable as possible.
 - [x] Support SocketIO.
 - [x] Support Middleware of [pyinstrument](https://pyinstrument.readthedocs.io/)
       to check your service performance.
+- [x] Support Middleware for collecting and exposing [Prometheus](https://prometheus.io/) metrics.
 
 **Note:** Check [Release Notes](https://authx.yezz.me/release/).
 

--- a/authx/middleware/__init__.py
+++ b/authx/middleware/__init__.py
@@ -1,4 +1,5 @@
+from authx.middleware.metrics import MetricsMiddleware, get_metrics
 from authx.middleware.Oauth2 import MiddlewareOauth2
 from authx.middleware.profiler import ProfilerMiddleware
 
-__all__ = ["MiddlewareOauth2", "ProfilerMiddleware"]
+__all__ = ["MiddlewareOauth2", "ProfilerMiddleware", "MetricsMiddleware", "get_metrics"]

--- a/authx/middleware/metrics.py
+++ b/authx/middleware/metrics.py
@@ -1,0 +1,96 @@
+import functools
+import os
+import time
+import typing
+
+import prometheus_client
+from fastapi import FastAPI, Request
+from prometheus_client.multiprocess import MultiProcessCollector
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Metrics middleware collecting prometheus metrics for each request."""
+
+    def __init__(
+        self,
+        app: FastAPI,
+        prefix: str = "authx_",
+        buckets: typing.Tuple[float, ...] = (
+            0.002,
+            0.05,
+            0.1,
+            prometheus_client.utils.INF,
+        ),
+    ) -> None:
+        """Initialize a new MetricsMiddleware instance."""
+        super().__init__(app)
+        self.request_count = request_count(prefix)
+        self.request_time = request_time(prefix, buckets)
+
+    async def dispatch(self, request: Request, call_next: typing.Callable):
+        """Record request method, path and status when dispatching."""
+        method = request.method
+        path = request.url.path
+        status = 500
+        begin = time.time()
+        try:
+            response = await call_next(request)
+            status = response.status_code
+        finally:
+            # track urls w/ params grouped, eg. /items/123 -> /items/{id}
+            router = request.scope.get("router")
+            endpoint = request.scope.get("endpoint")
+            if router and endpoint:
+                for route in router.routes:
+                    route_app = getattr(route, "app", None)
+                    route_endpoint = getattr(route, "endpoint", None)
+                    if endpoint in (route_app, route_endpoint):
+                        path = route.path
+                        break
+            end = time.time()
+            labels = [method, path, status]
+            self.request_count.labels(*labels).inc()
+            self.request_time.labels(*labels).observe(end - begin)
+        return response
+
+
+@functools.lru_cache()
+def request_count(prefix: str) -> prometheus_client.Counter:
+    """Return request count metric for the app prefix (cached/singleton)."""
+    return prometheus_client.Counter(
+        f"{prefix}requests_total",
+        "Total HTTP requests",
+        ("method", "path", "status"),
+        registry=get_registry(),
+    )
+
+
+@functools.lru_cache()
+def request_time(
+    prefix: str, buckets: typing.Tuple[float, ...]
+) -> prometheus_client.Histogram:
+    """Return request time metric for the app prefix (cached/singleton)."""
+    return prometheus_client.Histogram(
+        f"{prefix}request_duration_seconds",
+        "HTTP request duration in seconds",
+        ("method", "path", "status"),
+        buckets=buckets,
+        registry=get_registry(),
+    )
+
+
+@functools.lru_cache()
+def get_registry() -> prometheus_client.registry.CollectorRegistry:
+    """Get the metrics collector registry."""
+    registry = prometheus_client.CollectorRegistry()
+    if "PROMETHEUS_MULTIPROC_DIR" in os.environ:
+        MultiProcessCollector(registry)
+    return registry
+
+
+def get_metrics(_: Request) -> Response:
+    """Handler exposing the prometheus metrics."""
+    metrics = prometheus_client.generate_latest(get_registry())
+    return Response(metrics, media_type=prometheus_client.CONTENT_TYPE_LATEST)

--- a/docs/configuration/middleware/metrics.md
+++ b/docs/configuration/middleware/metrics.md
@@ -1,0 +1,24 @@
+# Metrics Using Prometheus
+
+Metrics collection with Prometheus relies on the pull model, meaning that Prometheus is responsible for getting metrics (scraping) from the services that it monitors. This is diametrically opposed from other tools like Graphite, which are passively waiting on clients to push their metrics to a known server.
+
+## Exposing and scraping metrics
+
+Clients have only one responsibility: make their metrics available for a Prometheus server to scrape. This is done by exposing an HTTP endpoint, usually /metrics, which returns the full list of metrics (with label sets) and their values. This endpoint is very cheap to call as it simply outputs the current value of each metric, without doing any calculation.
+
+![Prometheus scraping](https://blog.pvincent.io/images/prometheus-series/prometheus-service-scrape.png)
+
+On the Prometheus server side, each target (statically defined, or dynamically discovered) is scraped at a regular interval (scrape interval). Each scrape reads the /metrics to get the current state of the client metrics, and persists the values in the Prometheus time-series database.
+
+## Implementation in FastAPI applications
+
+Thats Work by adding a Middleware to your FastAPI application, work on collecting prometheus metrics for each request, and then to handle that we need a function `get_metrics` work on handling exposing the prometheus metrics into `/metrics` endpoint.
+
+```python
+from fastapi import FastAPI
+from authx.middleware import MetricsMiddleware, get_metrics
+
+app = FastAPI()
+app.add_middleware(MetricsMiddleware)
+app.add_route("/metrics", get_metrics)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,7 @@ library for FastAPI. It is built on top of
 - [x] Support SocketIO.
 - [x] Support Middleware of [pyinstrument](https://pyinstrument.readthedocs.io/)
       to check your service performance.
+- [x] Support Middleware for collecting and exposing [Prometheus](https://prometheus.io/) metrics.
 
 ## Project using
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - configuration/middleware/service-performance.md
       - configuration/middleware/example.md
       - configuration/middleware/profiling.md
+      - configuration/middleware/metrics.md
     - Socket:
       - Introduction: configuration/socket/index.md
   - Help AuthX - Get Help: help.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "python-socketio >=4.6.0,<5.7.1",
     "pyinstrument >=4.1.1,<4.2.0",
     "SQLAlchemy >=1.4.37,<=1.4.40",
+    "prometheus-client",
 ]
 
 dynamic = ["version"]

--- a/tests/middleware/test_metrics.py
+++ b/tests/middleware/test_metrics.py
@@ -1,0 +1,56 @@
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.testclient import TestClient
+from prometheus_client.parser import text_string_to_metric_families
+
+from authx.middleware import MetricsMiddleware, get_metrics
+
+
+@pytest.fixture(autouse=True)
+def env(monkeypatch):
+    """Run tests with 'PROMETHEUS_MULTIPROC_DIR' in the env by default."""
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", "/tmp")
+
+
+@pytest.fixture
+def client():
+    """Return a test client for a simple FastAPI instance with metrics."""
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+    app.add_route("/metrics", get_metrics)
+    app.add_route("/foo", lambda _: Response("bar"))
+    return TestClient(app)
+
+
+def test_metrics_keys(client):
+    """Test that all expected metric families are exported."""
+    metrics = scrape_metrics(client)
+    assert set(metrics.keys()) == {
+        "authx_request_duration_seconds",
+        "authx_requests",
+    }
+
+
+def test_metrics_values(client):
+    """Test that GET /foo is recorded via metrics."""
+    assert client.get("/foo")
+    metrics = scrape_metrics(client)
+
+    request_durations = metrics["authx_request_duration_seconds"]
+    assert "method=GET,path=/foo,status=200" in request_durations
+
+
+def scrape_metrics(client):
+    """GET /metrics response and return it parsed for asserting."""
+    response = client.get("/metrics")
+    metrics = {}
+    for metric in text_string_to_metric_families(response.text):
+        # skip standard python metrics
+        if not metric.name.startswith("authx_"):
+            continue
+        # "dictify" metrics for simple comparison in tests
+        metrics[metric.name] = labels = {}
+        for sample in metric.samples:
+            label = ",".join(f"{k}={v}" for k, v in sorted(sample.labels.items()))
+            labels[label] = sample.value
+    return metrics


### PR DESCRIPTION
FastAPI middleware for collecting and exposing Prometheus metrics.

## Usage

```py
from fastapi import FastAPI
from authx.middleware import MetricsMiddleware, get_metrics

app = FastAPI()
app.add_middleware(MetricsMiddleware)
app.add_route("/metrics", get_metrics)
```
