### PR TITLE
🐛  Support `aioredis` from redis package

### DIFF
--- a/authx/cache/redis.py
+++ b/authx/cache/redis.py
@@ -1,14 +1,17 @@
 from typing import Iterable, Optional, Union
 
-import redis
+from redis import asyncio as aioredis
 
 
 class RedisBackend:
-    """Setup the Redis connection for the backend using redis"""
+    """
+    Setup the Redis connection for the backend using aioredis.
 
-    _redis: Optional[redis.Redis] = None
+    """
 
-    def set_client(self, redis: redis.Redis) -> None:
+    _redis: Optional[aioredis.Redis] = None
+
+    def set_client(self, redis: aioredis.Redis) -> None:
         self._redis = redis
 
     async def get(self, key: str) -> str:
@@ -36,5 +39,6 @@ class RedisBackend:
         return await self._redis.incr(key)
 
     async def dispatch_action(self, channel: str, action: str, payload: dict) -> None:
+        # TODO: is publish_json exist in redis-py?
         await self._redis.publish_json(channel, {"action": action, "payload": payload})
         return None

--- a/authx/main.py
+++ b/authx/main.py
@@ -1,7 +1,7 @@
 from typing import Iterable, Optional
 
-import redis
 from fastapi import APIRouter, HTTPException, Request
+from redis import asyncio as aioredis
 
 from authx.backend import UsersRepo
 from authx.cache import RedisBackend
@@ -43,7 +43,7 @@ class authx:
             refresh_expiration,
         )
 
-    def set_cache(self, client: redis.Redis) -> None:
+    def set_cache(self, client: aioredis.Redis) -> None:
         self._cache_backend.set_client(client)
 
     async def get_user(self, request: Request) -> User:
@@ -194,5 +194,5 @@ class Authentication(authx):
     def search_router(self) -> APIRouter:
         return get_search_router(self._users_repo, self.admin_required)
 
-    def set_cache(self, cache_client: redis.Redis) -> None:
+    def set_cache(self, cache_client: aioredis.Redis) -> None:
         self._cache_backend.set_client(cache_client)

--- a/docs/configuration/cache/index.md
+++ b/docs/configuration/cache/index.md
@@ -14,7 +14,7 @@ of the Redis class and pass it to the `set_redis` method.
 
 ```python
 from authx import authx, RedisBackend
-from redis import Redis
+from redis import asyncio as Redis
 
 auth = authx()
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -6,6 +6,9 @@ rm -f `find . -type f -name '.*~' `
 rm -f `find . -type f -name .coverage`
 rm -f `find . -type f -name ".coverage.*"`
 rm -rf `find . -name __pycache__`
+rm -rf `find . -name authx_profiling_results.html`
+rm -rf `find . -name authx_profiling_results.json`
+rm -rf `find . -name users.db`
 rm -rf `find . -type d -name '*.egg-info' `
 rm -rf `find . -type d -name 'pip-wheel-metadata' `
 rm -rf `find . -type d -name .pytest_cache`

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+echo "ENV=${ENV}"
+echo "REDIS_URL-${REDIS_URL}"
+
+export PYTHONPATH=.
+
+# run redis container
+docker run -d -p 6379:6379 --name redis redis
+
+# run tests
+pytest --cov=authx --cov=tests -xv
+
+# Shutdown and remove redis container
+docker stop redis
+docker rm redis

--- a/tests/cache/test_cache_config.py
+++ b/tests/cache/test_cache_config.py
@@ -1,18 +1,12 @@
 import random
-import unittest
 from datetime import timedelta
-from unittest import mock
 
 from authx.cache.config import basicConfig, config
 
 
-@unittest.skip(
-    "Improve this test later while getting issues after adding the container of Redis to Github Workflow"
-)
-@mock.patch("authx.cache.config.uuid4")
-def testConfig(mock_uuid4):
-    config.genSessionId()
-    mock_uuid4.assert_called_once_with()  # pragma: no cover
+def test_config() -> None:
+    session_id = config.genSessionId().isnumeric()
+    assert session_id is not None
 
 
 def testBasicConfig():

--- a/tests/cache/test_http_cache.py
+++ b/tests/cache/test_http_cache.py
@@ -8,8 +8,8 @@ from fastapi.testclient import TestClient
 
 from authx import HTTPCache, cache, invalidate_cache
 
-REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/3")
-redis_client = redis.Redis.from_url(REDIS_URL)
+REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379/2")
+redis_client = redis.from_url(REDIS_URL)
 
 
 class User:

--- a/tests/middleware/test_middleware_Oauth2.py
+++ b/tests/middleware/test_middleware_Oauth2.py
@@ -24,7 +24,7 @@ class Test(TestCase):
         cls.client = TestClient(app)
 
     def test_redirects(self):
-        response = self.client.get("/", allow_redirects=False)
+        response = self.client.get("/", follow_redirects=False)
 
         self.assertEqual(302, response.status_code)
         url = URL(response.headers["Location"])

--- a/tests/routers/test_routers_social.py
+++ b/tests/routers/test_routers_social.py
@@ -50,7 +50,7 @@ def test_login(provider: str):
         f"authx.routers.social.SocialService.login_{provider}",
         mock.Mock(return_value="/"),
     ) as mock_method:
-        response = test_client.get(url, allow_redirects=False)
+        response = test_client.get(url, follow_redirects=False)
         mock_method.assert_called_once()
 
     assert response.status_code == 307
@@ -78,7 +78,7 @@ def test_callback(provider: str):
     )
     mock_resolve_user = patcher_resolve_user.start()
     url = app.url_path_for("social:callback", provider=provider)
-    response = test_client.get(url, allow_redirects=False)
+    response = test_client.get(url, follow_redirects=False)
 
     assert response.status_code == 307
 


### PR DESCRIPTION
# aioredis

---

## 📢🚨 Aioredis is now in redis-py 4.2.0rc1+ 🚨🚨

Aioredis is now in redis-py 4.2.0rc1+

To install, just do `pip install redis>=4.2.0rc1`. The code is almost the exact same. You will just need to import like so:

```python
from redis import asyncio as aioredis
```

This way you don't have to change all your code, just the imports.

https://github.com/redis/redis-py/releases/tag/v4.2.0rc1

From https://github.com/aio-libs/aioredis-py/blob/master/README.md