### PR TITLE
🐛  remove `print()` in the release file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
           )
           version = get_version()
           tweet = os.getenv("TWEET").format(version=version)
-          print(tweet)
           client.create_tweet(text=tweet)
 
         env:


### PR DESCRIPTION
i catch this while reading the latest changes