### PR TITLE
🐛  add `itsdangerous` to project dependencies level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
     "python-dateutil>=2.8,<3.0.0",
     "pytz>=2023.3,<2025.0",
     "python-jose>=3.3.0,<4.0.0",
+    "itsdangerous>=2.2.0,<3.0.0",
 ]
 
 dynamic = ["version"]


### PR DESCRIPTION
It is directly imported and used, but only specified in the testing requirements.

Resolves https://github.com/yezz123/authx/issues/663