### PR TITLE
♻️ Deprecate data keyword argument in `decode_token`

### DIFF
--- a/authx/exceptions.py
+++ b/authx/exceptions.py
@@ -95,3 +95,9 @@ class InvalidToken(Exception):
             errors (list[str]): list of errors
         """
         self.errors = errors
+
+
+class AuthxArgumentDeprecationWarning(DeprecationWarning):
+    """Raised when deprecated argument is used."""
+
+    pass

--- a/authx/token.py
+++ b/authx/token.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union
 import jwt
 
 from authx._internal._utils import RESERVED_CLAIMS, get_now, get_now_ts, get_uuid
-from authx.exceptions import JWTDecodeError
+from authx.exceptions import AuthxArgumentDeprecationWarning, JWTDecodeError
 from authx.types import (
     AlgorithmType,
     DateTimeExpression,
@@ -107,7 +107,7 @@ def decode_token(
     if data is not None:
         warnings.warn(
             "passing data keyword argument to decode_token() is deprecated and will be removed in authx version 2.",
-            DeprecationWarning,
+            AuthxArgumentDeprecationWarning,
             stacklevel=2,
         )
 

--- a/authx/token.py
+++ b/authx/token.py
@@ -3,6 +3,7 @@
 import datetime
 from collections.abc import Sequence
 from typing import Any, Optional, Union
+import warnings
 
 import jwt
 
@@ -103,6 +104,14 @@ def decode_token(
     data: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     """Decode a token."""
+    if data is not None:
+        warnings.warn(
+            "passing data keyword argument to decode_token() is deprecated "
+            "and will be removed in authx version 2.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     # Default to HS256 if no algorithms are provided
     if algorithms is None:  # pragma: no cover
         algorithms = ["HS256"]  # pragma: no cover
@@ -117,7 +126,6 @@ def decode_token(
             audience=audience,
             issuer=issuer,
             options={"verify_signature": verify},
-            data=data,
         )
     except Exception as e:
         raise JWTDecodeError(*e.args) from e

--- a/authx/token.py
+++ b/authx/token.py
@@ -1,9 +1,9 @@
 """Token encoding and decoding functions."""
 
 import datetime
+import warnings
 from collections.abc import Sequence
 from typing import Any, Optional, Union
-import warnings
 
 import jwt
 
@@ -106,8 +106,7 @@ def decode_token(
     """Decode a token."""
     if data is not None:
         warnings.warn(
-            "passing data keyword argument to decode_token() is deprecated "
-            "and will be removed in authx version 2.",
+            "passing data keyword argument to decode_token() is deprecated and will be removed in authx version 2.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from authx.exceptions import JWTDecodeError
+from authx.exceptions import AuthxArgumentDeprecationWarning, JWTDecodeError
 from authx.token import create_token, decode_token
 
 
@@ -298,3 +298,15 @@ def test_verify_token():
         decode_token(token, key=KEY, algorithms=[ALGO], verify=True)
     time.sleep(SLEEP_TIME)
     decode_token(token, key=KEY, algorithms=[ALGO], verify=True)
+
+
+def test_decode_token_raise_data_argument_deprecated():
+    KEY = "SECRET"
+
+    token = create_token(uid="TEST", key="SECRET")
+    expected_warning_message = (
+        r".*passing data keyword argument to decode_token\(\) is deprecated and will be removed in authx version 2.*"
+    )
+
+    with pytest.warns(AuthxArgumentDeprecationWarning, match=expected_warning_message):
+        decode_token(token, key=KEY, data={})


### PR DESCRIPTION
It just used to pass this parameter to jwt.decode but it deprecated.
https://github.com/jpadilla/pyjwt/blob/29fbfc/jwt/api_jwt.py#L343-L350