### PR TITLE
✨ added support for `JWT_COOKIE_HTTP_ONLY`

### DIFF
--- a/authx/config.py
+++ b/authx/config.py
@@ -64,6 +64,7 @@ class AuthXConfig(BaseSettings):
     JWT_COOKIE_MAX_AGE: Optional[int] = None
     JWT_COOKIE_SAMESITE: Optional[SameSitePolicy] = "lax"
     JWT_COOKIE_SECURE: bool = True
+    JWT_COOKIE_HTTP_ONLY: bool = True
     JWT_REFRESH_COOKIE_NAME: str = "refresh_token_cookie"
     JWT_REFRESH_COOKIE_PATH: str = "/"
     JWT_SESSION_COOKIE: bool = True

--- a/authx/main.py
+++ b/authx/main.py
@@ -193,7 +193,7 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
             domain=self.config.JWT_COOKIE_DOMAIN,
             samesite=self.config.JWT_COOKIE_SAMESITE,
             secure=self.config.JWT_COOKIE_SECURE,
-            httponly=True,
+            httponly=self.config.JWT_COOKIE_HTTP_ONLY,
             max_age=max_age or self.config.JWT_COOKIE_MAX_AGE,
         )
         # Set CSRF

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,7 @@ def config() -> AuthXConfig:
 
 
 @pytest.fixture(scope="function")
-def request_headers(config: AuthXConfig) -> list[list[str]]:
+def request_headers(config: AuthXConfig) -> list[list[bytes]]:
     return [
         [
             f"{config.JWT_HEADER_NAME.lower()}".encode(),
@@ -38,7 +38,7 @@ def request_headers(config: AuthXConfig) -> list[list[str]]:
 
 
 @pytest.fixture(scope="function")
-def request_csrf_headers(config: AuthXConfig) -> list[list[str]]:
+def request_csrf_headers(config: AuthXConfig) -> list[list[bytes]]:
     return [
         [
             f"{config.JWT_ACCESS_CSRF_HEADER_NAME.lower()}".encode(),
@@ -52,7 +52,7 @@ def request_csrf_headers(config: AuthXConfig) -> list[list[str]]:
 
 
 @pytest.fixture(scope="function")
-def request_cookies(config: AuthXConfig) -> list[list[str]]:
+def request_cookies(config: AuthXConfig) -> list[list[bytes]]:
     return [
         [b"content-type", b"application/json"],
         [


### PR DESCRIPTION
As per the issue #746 added support for this. Previously, It was just a default `http_only=True` as shown but we have added support in order to make it configurable.
https://github.com/yezz123/authx/blob/6792c429dd682568d62f626a08c76b9dd7dda209/authx/main.py#L196

Recommendation:
For any cookie that deals with authentication, session management, authorization, or sensitive user data, you should ALWAYS set `http_only=True`. This is a fundamental security layer that helps prevent one of the most common web vulnerabilities (XSS) from becoming a full-blown account takeover.
So, while `http_only=True` is a golden rule for sensitive cookies like session IDs, the CSRF cookie is a special case where `http_only=False` is intentional and part of its effective design.

