### PR TITLE
🐛  use refresh parameter in `_get_token_from_headers()`

### DIFF
--- a/authx/core.py
+++ b/authx/core.py
@@ -25,7 +25,12 @@ async def _get_token_from_headers(
     else:
         token = auth_header
 
-    return RequestToken(token=token, csrf=None, location="headers")
+    return RequestToken(
+        token=token,
+        csrf=None,
+        type=("refresh" if refresh else "access"),
+        location="headers",
+    )
 
 
 async def _get_token_from_cookies(


### PR DESCRIPTION
The _get_token_from_headers function was ignoring the refresh parameter when constructing RequestToken, always returning type="access" instead of setting it based on the refresh flag.

This caused AccessTokenRequiredError when verifying refresh tokens from headers with verify_type=True, since RequestToken.type was "access" but TokenPayload.type was "refresh".

Now _get_token_from_headers correctly sets type=("refresh" if refresh else "access") consistent with _get_token_from_cookies and _get_token_from_json.

Fixes #775