### PR TITLE
:sparkles: Drop pydantic v1 & support only pydantic v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,51 +32,9 @@ jobs:
       - name: Typecheck with mypy
         run: bash scripts/mypy.sh
 
-  tests-pydantic-v2:
+  tests:
 
-    name: test py${{ matrix.python-version }} on ${{ matrix.os }} with pydantic v2
-
-    runs-on: ${{ matrix.os }}-latest
-
-
-    strategy:
-
-      matrix:
-
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13"]
-
-        os: [ubuntu]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: setup UV
-        uses: yezz123/setup-uv@v4.1
-        with:
-          uv-venv: ".venv"
-
-      - name: Install Dependencies
-        run: uv sync --group test --all-extras
-
-      - name: Test with pytest - ${{ matrix.os }} - py${{ matrix.python-version }}
-        run: bash scripts/test.sh
-        env:
-          CONTEXT: ${{ runner.os }}-py${{ matrix.python-version }}-with-deps
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-
-  tests-pydantic-v1:
-
-    name: test py${{ matrix.python-version }} on ${{ matrix.os }} with pydantic v1
+    name: test py${{ matrix.python-version }} on ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -104,9 +62,6 @@ jobs:
 
       - name: Install Dependencies
         run: uv sync --group test --all-extras
-
-      - name: Install pydantic v1
-        run: uv pip install pydantic==1.10.17
 
       - name: Test with pytest - ${{ matrix.os }} - py${{ matrix.python-version }}
         run: bash scripts/test.sh
@@ -166,7 +121,7 @@ jobs:
   check:
     if: always()
 
-    needs: [mypy, tests-pydantic-v2, tests-pydantic-v1, test-extra]
+    needs: [mypy, tests, test-extra]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/authx/config.py
+++ b/authx/config.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from jwt.algorithms import get_default_algorithms, requires_cryptography
 from pydantic import Field
-from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic_settings import BaseSettings
 
 from authx.exceptions import BadConfigurationError
 from authx.types import (
@@ -16,11 +16,6 @@ from authx.types import (
     StringOrSequence,
     TokenLocations,
 )
-
-if PYDANTIC_V2 := PYDANTIC_VERSION.startswith("2."):
-    from pydantic_settings import BaseSettings  # pragma: no cover
-else:
-    from pydantic import BaseSettings  # type: ignore # pragma: no cover
 
 
 class AuthXConfig(BaseSettings):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 dependencies = [
     "fastapi >=0.111.0",
     "pyjwt[crypto] >=2.6.0,<3.0.0",
-    "pydantic >=1.7.4,!=1.8,!=1.8.1,<3.0.0",
+    "pydantic >=2.0.0,<3.0.0",
     "pydantic-settings >=2.1.0",
     "python-dateutil>=2.8,<3.0.0",
     "pytz>=2023.3,<2026.0",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10,7 +10,7 @@ from authx.exceptions import (
     RefreshTokenRequiredError,
     TokenTypeError,
 )
-from authx.schema import PYDANTIC_V2, RequestToken, TokenPayload
+from authx.schema import RequestToken, TokenPayload
 
 
 @pytest.fixture(scope="function")
@@ -334,8 +334,7 @@ def test_payload_has_scopes_empty(valid_payload: TokenPayload):
     assert not valid_payload.has_scopes("read", "write")
 
 
-@pytest.mark.skipif(not PYDANTIC_V2, reason="Test for Pydantic V2")
-def test_payload_extra_dict_pydantic_v2():
+def test_payload_extra_dict():
     payload = TokenPayload(
         type="access",
         fresh=True,
@@ -348,22 +347,6 @@ def test_payload_extra_dict_pydantic_v2():
         extra="EXTRA",
     )
     assert payload.extra_dict == {}
-
-
-@pytest.mark.skipif(PYDANTIC_V2, reason="Test for Pydantic V1")
-def test_payload_extra_dict_pydantic_v1():
-    payload = TokenPayload(
-        type="access",
-        fresh=True,
-        sub="BOOOM",
-        csrf="CSRF_TOKEN",
-        scopes=["read", "write"],
-        exp=datetime.timedelta(minutes=20),
-        nbf=datetime.datetime(2000, 1, 1, 12, 0, tzinfo=datetime.timezone.utc),
-        iat=datetime.datetime(2000, 1, 1, 12, 0, tzinfo=datetime.timezone.utc).timestamp(),
-        extra="EXTRA",
-    )
-    assert payload.extra_dict == {"extra": "EXTRA"}
 
 
 def test_verify_token_type_exception():
@@ -402,18 +385,10 @@ def test_token_payload_creation(sample_payload):
     assert payload.scopes == ["read", "write"]
 
 
-@pytest.mark.skipif(not PYDANTIC_V2, reason="Test for Pydantic V2")
-def test_token_payload_extra_fields_pydantic_v2(sample_payload):
+def test_token_payload_extra_fields(sample_payload):
     sample_payload["extra_field"] = "extra_value"
     payload = TokenPayload(**sample_payload)
     assert payload.extra_dict == {}
-
-
-@pytest.mark.skipif(PYDANTIC_V2, reason="Test for Pydantic V1")
-def test_token_payload_extra_fields_pydantic_v1(sample_payload):
-    sample_payload["extra_field"] = "extra_value"
-    payload = TokenPayload(**sample_payload)
-    assert payload.extra_dict == {"extra_field": "extra_value", "name": "John Doe"}
 
 
 def test_token_payload_encode_decode():

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ test = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.111.0" },
     { name = "itsdangerous", specifier = ">=2.2.0,<3.0.0" },
-    { name = "pydantic", specifier = ">=1.7.4,!=1.8,!=1.8.1,<3.0.0" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.6.0,<3.0.0" },
     { name = "python-dateutil", specifier = ">=2.8,<3.0.0" },


### PR DESCRIPTION
- Updated `pyproject.toml` and `uv.lock` to require Pydantic version 2.0.0 or higher.
- Refactored `authx/config.py` and `authx/schema.py` to utilize Pydantic v2 features, removing version checks and legacy code.
- Simplified CI workflow by consolidating Pydantic version tests into a single job.
- Adjusted tests in `tests/test_schema.py` to align with the new Pydantic v2 structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Pydantic v2-only migration**
> 
> - Require `pydantic >=2.0.0,<3.0.0` in `pyproject.toml` and `uv.lock`
> - Refactor `authx/config.py` and `authx/schema.py` to v2 APIs (`BaseSettings`, `ConfigDict`, `field_validator`) and remove version checks/v1 code paths
> - Standardize validation/serialization to `model_validate`/`model_dump`; `TokenPayload.extra_dict` now excludes extras by default
> - Update tests in `tests/test_schema.py` to v2 behavior and drop v1-conditional tests
> 
> **CI simplification**
> 
> - Consolidate Pydantic v1/v2 matrices into a single `tests` job and update `check.needs` accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 406e1792a59b9ed6f1b72ceb051368f7074fa4db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->