### PR TITLE
:bug: Improve CSRF error handling and messaging

### DIFF
--- a/authx/_internal/_error.py
+++ b/authx/_internal/_error.py
@@ -11,7 +11,7 @@ class _ErrorHandler:
 
     MSG_TokenError = "Token Error"
     MSG_MissingTokenError = "Missing JWT in request"
-    MSG_MissingCSRFTokenError = "Missing CSRF double submit token in request"
+    MSG_MissingCSRFTokenError = None  # Use detailed exception message
     MSG_TokenTypeError = "Bad token type"
     MSG_RevokedTokenError = "Invalid token"
     MSG_TokenRequiredError = "Token required"
@@ -42,7 +42,9 @@ class _ErrorHandler:
         if message is None:
             default_message = str(exc)
             attr_name = f"MSG_{exc.__class__.__name__}"
-            message = getattr(self, attr_name, default_message)
+            attr_message = getattr(self, attr_name, None)
+            # Use attribute message if available, otherwise use exception message
+            message = attr_message if attr_message is not None else default_message
 
         return JSONResponse(
             status_code=status_code,
@@ -84,7 +86,7 @@ class _ErrorHandler:
             app,
             exception=exceptions.MissingCSRFTokenError,
             status_code=401,
-            message=self.MSG_MissingCSRFTokenError,
+            message=None,  # Use detailed exception message for better user guidance
         )
         self._set_app_exception_handler(
             app,

--- a/authx/schema.py
+++ b/authx/schema.py
@@ -351,7 +351,11 @@ class RequestToken(BaseModel):
 
         if verify_csrf and self.location == "cookies":
             if self.csrf is None:
-                raise CSRFError(f"Missing CSRF token in {self.location}")
+                raise CSRFError(
+                    f"Missing CSRF token in request. Include CSRF token from the "
+                    f"'{self.location}' in the 'X-CSRF-TOKEN' header. "
+                    f"To disable CSRF protection, set JWT_COOKIE_CSRF_PROTECT=False."
+                )
             if payload.csrf is None:
                 raise CSRFError("Cookies token missing CSRF claim")  # pragma: no cover
             if not compare_digest(self.csrf, payload.csrf):


### PR DESCRIPTION
Fixes #720 

- Enhanced the error message for missing CSRF tokens to provide detailed guidance on including the token in requests and disabling CSRF protection.
- Updated the error handler to use a more informative message for MissingCSRFTokenError, ensuring users receive helpful instructions.
- Added tests to verify that the detailed error message is correctly displayed when a CSRF token is missing, improving user experience and clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves CSRF usability by surfacing detailed error messages and ensuring FastAPI returns the exception text for missing CSRF tokens.
> 
> - Error handler: `MSG_MissingCSRFTokenError` set to `None`; when `message=None`, `_error_handler` now uses the exception message if no class-level default exists. `handle_errors` registers `MissingCSRFTokenError` with `message=None` so clients see detailed guidance.
> - CSRF validation: `RequestToken.verify` raises `CSRFError` with explicit instructions (include CSRF from `cookies` in `X-CSRF-TOKEN`, or disable via `JWT_COOKIE_CSRF_PROTECT=False`).
> - Tests: Added assertions to ensure detailed CSRF messages are returned (`test_csrf_error_message_is_detailed`, `test_missing_csrf_token_error_shows_detailed_message`) and adjusted error handler tests to reflect new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 619c1548d93755380c1c98cf81b9e479cf317d0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->