### PR TITLE
✨ Add Jinja2 template engine support documentation and examples

### DIFF
--- a/docs/extra/templates.md
+++ b/docs/extra/templates.md
@@ -1,0 +1,353 @@
+# Using with Template Engines (Jinja2)
+
+AuthX works seamlessly with server-side rendered (SSR) applications using template engines like Jinja2. This guide covers the key differences from API authentication and provides a complete example.
+
+## Key Differences from API Authentication
+
+| Aspect | API (JSON) | Templates (SSR) |
+|--------|------------|-----------------|
+| Token Location | Headers | Cookies |
+| Response Type | JSON | HTML/Redirect |
+| Error Handling | HTTP status codes | Redirect to login |
+| CSRF | Optional | **Required** for forms |
+
+## Quick Setup
+
+### 1. Configuration
+
+For template-based apps, use cookie authentication:
+
+```python
+from authx import AuthX, AuthXConfig
+
+config = AuthXConfig(
+    JWT_SECRET_KEY="your-secret-key",
+    # Cookie-based auth for SSR
+    JWT_TOKEN_LOCATION=["cookies"],
+    JWT_COOKIE_SECURE=False,      # True in production (HTTPS)
+    JWT_COOKIE_HTTP_ONLY=True,    # Prevent JS access to token
+    # CSRF protection for forms
+    JWT_COOKIE_CSRF_PROTECT=True,
+    JWT_CSRF_CHECK_FORM=True,     # Check CSRF in form data
+    JWT_ACCESS_CSRF_FIELD_NAME="csrf_token",
+)
+
+auth = AuthX(config=config)
+```
+
+### 2. Setup Jinja2 Templates
+
+```python
+from fastapi import FastAPI
+from fastapi.templating import Jinja2Templates
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+```
+
+---
+
+## Authentication Flow
+
+### Login Page (GET)
+
+Render the login form:
+
+```python
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request, error: str = None):
+    return templates.TemplateResponse(
+        "login.html",
+        {"request": request, "error": error}
+    )
+```
+
+### Login Submit (POST)
+
+Handle form submission, set cookies, redirect:
+
+```python
+from fastapi import Form
+from fastapi.responses import RedirectResponse
+
+@app.post("/login")
+async def login_submit(
+    response: Response,
+    username: str = Form(...),
+    password: str = Form(...),
+):
+    # Validate credentials
+    if not validate_user(username, password):
+        return templates.TemplateResponse(
+            "login.html",
+            {"request": request, "error": "Invalid credentials"},
+            status_code=401
+        )
+
+    # Create token and set cookie
+    access_token = auth.create_access_token(uid=username)
+
+    redirect = RedirectResponse(url="/dashboard", status_code=303)
+    auth.set_access_cookies(access_token, redirect)
+
+    return redirect
+```
+
+### Logout
+
+Clear cookies and redirect:
+
+```python
+@app.post("/logout")
+async def logout():
+    response = RedirectResponse(url="/login", status_code=303)
+    auth.unset_cookies(response)
+    return response
+```
+
+---
+
+## Protected Routes
+
+### Redirect-Based Auth Dependency
+
+Create a dependency that redirects to login instead of returning 401:
+
+```python
+from authx.exceptions import AuthXException
+
+class RedirectToLogin(Exception):
+    def __init__(self, url: str = "/login"):
+        self.url = url
+
+@app.exception_handler(RedirectToLogin)
+async def redirect_handler(request: Request, exc: RedirectToLogin):
+    return RedirectResponse(url=exc.url, status_code=303)
+
+async def require_auth(request: Request) -> dict:
+    """Dependency that redirects to login if not authenticated."""
+    try:
+        token = await auth.get_access_token_from_request(request)
+        payload = auth.verify_token(token, verify_csrf=False)
+        return {"username": payload.sub}
+    except AuthXException:
+        # Redirect to login with return URL
+        raise RedirectToLogin(f"/login?next={request.url.path}")
+```
+
+### Protected Template Route
+
+```python
+from fastapi import Depends
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(
+    request: Request,
+    user: dict = Depends(require_auth)
+):
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,  # Pass to template for forms
+        }
+    )
+```
+
+---
+
+## CSRF Protection in Forms
+
+When using cookie-based auth, **CSRF protection is essential** for form submissions.
+
+### Include CSRF Token in Templates
+
+```html
+<form action="/submit" method="post">
+    <!-- Hidden CSRF token field -->
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+    <input type="text" name="data">
+    <button type="submit">Submit</button>
+</form>
+```
+
+### Handling Form Submissions
+
+```python
+@app.post("/submit")
+async def submit_form(
+    request: Request,
+    user: dict = Depends(require_auth),
+    data: str = Form(...),
+    csrf_token: str = Form(...),  # CSRF validated automatically
+):
+    # Process form data
+    return RedirectResponse(url="/dashboard", status_code=303)
+```
+
+### JavaScript AJAX Requests
+
+For JavaScript requests, read the CSRF token from the cookie:
+
+```javascript
+function getCsrfToken() {
+    return document.cookie
+        .split('; ')
+        .find(row => row.startsWith('csrf_access_token='))
+        ?.split('=')[1];
+}
+
+fetch('/api/action', {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-TOKEN': getCsrfToken()
+    },
+    body: JSON.stringify({ data: 'value' })
+});
+```
+
+---
+
+## Complete Example
+
+Here's a minimal complete example:
+
+```python
+from fastapi import Depends, FastAPI, Form, Request, Response
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from authx import AuthX, AuthXConfig
+from authx.exceptions import AuthXException
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+config = AuthXConfig(
+    JWT_SECRET_KEY="secret",
+    JWT_TOKEN_LOCATION=["cookies"],
+    JWT_COOKIE_CSRF_PROTECT=True,
+    JWT_CSRF_CHECK_FORM=True,
+)
+auth = AuthX(config=config)
+
+
+# Simple user store
+USERS = {"admin": "password123"}
+
+
+class RedirectToLogin(Exception):
+    pass
+
+
+@app.exception_handler(RedirectToLogin)
+async def handle_redirect(request, exc):
+    return RedirectResponse("/login", status_code=303)
+
+
+async def require_auth(request: Request):
+    try:
+        token = await auth.get_access_token_from_request(request)
+        return auth.verify_token(token, verify_csrf=False)
+    except AuthXException:
+        raise RedirectToLogin()
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.post("/login")
+async def login(username: str = Form(...), password: str = Form(...)):
+    if USERS.get(username) != password:
+        return RedirectResponse("/login?error=1", status_code=303)
+
+    token = auth.create_access_token(uid=username)
+    response = RedirectResponse("/dashboard", status_code=303)
+    auth.set_access_cookies(token, response)
+    return response
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(request: Request, user=Depends(require_auth)):
+    csrf = request.cookies.get("csrf_access_token", "")
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {"request": request, "user": user.sub, "csrf_token": csrf}
+    )
+
+
+@app.post("/logout")
+async def logout():
+    response = RedirectResponse("/login", status_code=303)
+    auth.unset_cookies(response)
+    return response
+```
+
+---
+
+## Template Examples
+
+### login.html
+
+```html
+<!DOCTYPE html>
+<html>
+<head><title>Login</title></head>
+<body>
+    <h1>Login</h1>
+    <form method="post" action="/login">
+        <input type="text" name="username" placeholder="Username" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>
+```
+
+### dashboard.html
+
+```html
+<!DOCTYPE html>
+<html>
+<head><title>Dashboard</title></head>
+<body>
+    <h1>Welcome, {{ user }}!</h1>
+
+    <form method="post" action="/logout">
+        <button type="submit">Logout</button>
+    </form>
+
+    <!-- Example form with CSRF -->
+    <form method="post" action="/action">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <button type="submit">Do Action</button>
+    </form>
+</body>
+</html>
+```
+
+---
+
+## Full Working Example
+
+For a complete working example with styled templates, see:
+
+- [jinja2_templates.py](https://github.com/yezz123/authx/blob/main/examples/examples/jinja2_templates.py)
+- [Templates folder](https://github.com/yezz123/authx/tree/main/examples/examples/templates/jinja2)
+
+Run the example:
+
+```bash
+cd examples/examples
+python jinja2_templates.py
+```
+
+Then visit `http://localhost:8000` and login with `admin` / `admin123`.

--- a/examples/examples/jinja2_templates.py
+++ b/examples/examples/jinja2_templates.py
@@ -1,0 +1,323 @@
+"""AuthX with Jinja2 Template Engine Example.
+
+This example demonstrates how to use AuthX with Jinja2 templates for
+server-side rendered (SSR) web applications with a traditional login flow.
+
+Flow:
+    login.html --> POST /login --> dashboard.html --> POST /logout --> login.html
+                                       |
+                                       +--> process.html (/route1, /route2, etc.)
+
+Key concepts:
+- Cookie-based authentication (tokens stored in HTTP-only cookies)
+- Redirect-based flow (not JSON responses)
+- CSRF protection for form submissions
+- Protected routes that redirect to login on auth failure
+"""
+
+import os
+from pathlib import Path
+from typing import Annotated, Optional
+
+from fastapi import Depends, FastAPI, Form, Request, Response
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from authx import AuthX, AuthXConfig
+from authx.exceptions import AuthXException
+
+# Create FastAPI app
+app = FastAPI(title="AuthX Jinja2 Templates Example")
+
+# Setup templates directory
+TEMPLATES_DIR = Path(__file__).parent / "templates" / "jinja2"
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+# Configure AuthX for cookie-based authentication
+auth_config = AuthXConfig(
+    JWT_ALGORITHM="HS256",
+    JWT_SECRET_KEY="your-secret-key",  # Use env var in production
+    # Cookie-based auth for SSR applications
+    JWT_TOKEN_LOCATION=["cookies"],
+    JWT_ACCESS_COOKIE_NAME="access_token_cookie",
+    JWT_REFRESH_COOKIE_NAME="refresh_token_cookie",
+    # Cookie security settings
+    JWT_COOKIE_SECURE=False,  # Set True in production (HTTPS)
+    JWT_COOKIE_HTTP_ONLY=True,  # Prevent JavaScript access
+    JWT_COOKIE_SAMESITE="lax",  # CSRF protection
+    # Enable CSRF protection for form submissions
+    JWT_COOKIE_CSRF_PROTECT=True,
+    JWT_CSRF_IN_COOKIES=True,
+    JWT_ACCESS_CSRF_COOKIE_NAME="csrf_access_token",
+    JWT_ACCESS_CSRF_HEADER_NAME="X-CSRF-TOKEN",
+    JWT_CSRF_CHECK_FORM=True,  # Check CSRF in form data
+    JWT_ACCESS_CSRF_FIELD_NAME="csrf_token",  # Form field name for CSRF
+)
+
+auth = AuthX(config=auth_config)
+auth.handle_errors(app)
+
+# Sample user database
+USERS = {
+    "admin": {"password": "admin123", "name": "Administrator", "role": "admin"},
+    "user": {"password": "user123", "name": "Regular User", "role": "user"},
+}
+
+
+async def get_current_user_optional(request: Request) -> Optional[dict]:
+    """Get current user from cookie, return None if not authenticated."""
+    try:
+        token = await auth.get_access_token_from_request(request, locations=["cookies"])
+        payload = auth.verify_token(token, verify_csrf=False)  # Don't verify CSRF on GET
+        username = payload.sub
+        if username in USERS:
+            return {"username": username, **USERS[username]}
+    except AuthXException:
+        pass
+    return None
+
+
+class RedirectToLogin(Exception):
+    """Custom exception to trigger redirect to login page."""
+
+    def __init__(self, redirect_url: str = "/login"):
+        self.redirect_url = redirect_url
+
+
+async def require_auth(request: Request) -> dict:
+    """Dependency that requires authentication, redirects to login if not authenticated."""
+    user = await get_current_user_optional(request)
+    if user is None:
+        # Store the original URL to redirect back after login
+        redirect_url = f"/login?next={request.url.path}"
+        raise RedirectToLogin(redirect_url)
+    return user
+
+
+# Type alias for authenticated user dependency (avoids B008 linter warning)
+AuthUser = Annotated[dict, Depends(require_auth)]
+
+
+@app.exception_handler(RedirectToLogin)
+async def redirect_to_login_handler(request: Request, exc: RedirectToLogin):
+    """Handle RedirectToLogin exception by redirecting to login page."""
+    return RedirectResponse(url=exc.redirect_url, status_code=303)
+
+
+# ============================================================================
+# PUBLIC ROUTES
+# ============================================================================
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    """Home page - public, shows login link or dashboard link based on auth status."""
+    user = await get_current_user_optional(request)
+    return templates.TemplateResponse(
+        "home.html",
+        {"request": request, "user": user},
+    )
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request, error: str = None, next: str = "/dashboard"):
+    """Render login form."""
+    # If already logged in, redirect to dashboard
+    user = await get_current_user_optional(request)
+    if user:
+        return RedirectResponse(url=next, status_code=303)
+
+    return templates.TemplateResponse(
+        "login.html",
+        {"request": request, "error": error, "next": next},
+    )
+
+
+@app.post("/login")
+async def login_submit(
+    request: Request,
+    response: Response,
+    username: str = Form(...),
+    password: str = Form(...),
+    next: str = Form("/dashboard"),
+):
+    """Handle login form submission."""
+    # Validate credentials
+    if username not in USERS or USERS[username]["password"] != password:
+        return templates.TemplateResponse(
+            "login.html",
+            {"request": request, "error": "Invalid username or password", "next": next},
+            status_code=401,
+        )
+
+    # Create tokens
+    access_token = auth.create_access_token(uid=username)
+    refresh_token = auth.create_refresh_token(uid=username)
+
+    # Create redirect response
+    redirect = RedirectResponse(url=next, status_code=303)
+
+    # Set cookies on the redirect response
+    auth.set_access_cookies(access_token, redirect)
+    auth.set_refresh_cookies(refresh_token, redirect)
+
+    return redirect
+
+
+@app.post("/logout")
+async def logout(request: Request):
+    """Handle logout - clear cookies and redirect to login."""
+    response = RedirectResponse(url="/login", status_code=303)
+    auth.unset_cookies(response)
+    return response
+
+
+# ============================================================================
+# PROTECTED ROUTES - Require authentication
+# ============================================================================
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard(request: Request, user: AuthUser):
+    """Protected dashboard page."""
+    # Get CSRF token for forms on this page
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,
+        },
+    )
+
+
+@app.get("/process", response_class=HTMLResponse)
+async def process_page(request: Request, user: AuthUser):
+    """Protected process page with sub-routes."""
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "process.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,
+            "current_route": "process",
+        },
+    )
+
+
+@app.get("/route1", response_class=HTMLResponse)
+async def route1(request: Request, user: AuthUser):
+    """Protected route 1."""
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "process.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,
+            "current_route": "route1",
+            "message": "Welcome to Route 1 - Data Processing",
+        },
+    )
+
+
+@app.get("/route2", response_class=HTMLResponse)
+async def route2(request: Request, user: AuthUser):
+    """Protected route 2."""
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "process.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,
+            "current_route": "route2",
+            "message": "Welcome to Route 2 - Reports",
+        },
+    )
+
+
+@app.get("/route3", response_class=HTMLResponse)
+async def route3(request: Request, user: AuthUser):
+    """Protected route 3."""
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "process.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,
+            "current_route": "route3",
+            "message": "Welcome to Route 3 - Settings",
+        },
+    )
+
+
+@app.get("/route4", response_class=HTMLResponse)
+async def route4(request: Request, user: AuthUser):
+    """Protected route 4."""
+    csrf_token = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "process.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token,
+            "current_route": "route4",
+            "message": "Welcome to Route 4 - Analytics",
+        },
+    )
+
+
+# ============================================================================
+# PROTECTED FORM SUBMISSION (demonstrates CSRF protection)
+# ============================================================================
+
+
+@app.post("/process/action", response_class=HTMLResponse)
+async def process_action(
+    request: Request,
+    user: AuthUser,
+    action: str = Form(...),
+    csrf_token: str = Form(...),  # CSRF token from form
+):
+    """Handle a protected form submission with CSRF validation."""
+    # The CSRF token is validated automatically by AuthX when JWT_CSRF_CHECK_FORM=True
+    # For manual validation, you would verify it matches the cookie
+
+    csrf_token_cookie = request.cookies.get("csrf_access_token", "")
+
+    return templates.TemplateResponse(
+        "process.html",
+        {
+            "request": request,
+            "user": user,
+            "csrf_token": csrf_token_cookie,
+            "current_route": "process",
+            "message": f"Action '{action}' completed successfully!",
+        },
+    )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    # Ensure templates directory exists
+    TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+
+    port = int(os.environ.get("PORT", 8000))
+    print(f"Starting server on http://localhost:{port}")
+    print(f"Templates directory: {TEMPLATES_DIR}")
+    print("\nTest credentials:")
+    print("  Username: admin, Password: admin123")
+    print("  Username: user, Password: user123")
+
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/examples/examples/templates/jinja2/base.html
+++ b/examples/examples/templates/jinja2/base.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}AuthX Jinja2 Example{% endblock %}</title>
+    <style>
+        :root {
+            --bg-primary: #0f172a;
+            --bg-secondary: #1e293b;
+            --bg-tertiary: #334155;
+            --text-primary: #f8fafc;
+            --text-secondary: #94a3b8;
+            --accent: #3b82f6;
+            --accent-hover: #2563eb;
+            --success: #22c55e;
+            --error: #ef4444;
+            --border: #475569;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+            background: linear-gradient(135deg, var(--bg-primary) 0%, #1a1a2e 100%);
+            color: var(--text-primary);
+            min-height: 100vh;
+            line-height: 1.6;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 20px;
+        }
+
+        /* Navigation */
+        nav {
+            background: var(--bg-secondary);
+            border-bottom: 1px solid var(--border);
+            padding: 1rem 0;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        nav .container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--accent);
+            text-decoration: none;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 1.5rem;
+            align-items: center;
+        }
+
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+
+        .nav-links a:hover,
+        .nav-links a.active {
+            color: var(--accent);
+        }
+
+        .user-info {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .user-badge {
+            background: var(--bg-tertiary);
+            padding: 0.5rem 1rem;
+            border-radius: 2rem;
+            font-size: 0.875rem;
+        }
+
+        /* Buttons */
+        .btn {
+            display: inline-block;
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            font-weight: 500;
+            text-decoration: none;
+            border: none;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-size: 1rem;
+        }
+
+        .btn-primary {
+            background: var(--accent);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: var(--accent-hover);
+        }
+
+        .btn-secondary {
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+        }
+
+        .btn-secondary:hover {
+            background: var(--border);
+        }
+
+        .btn-danger {
+            background: var(--error);
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background: #dc2626;
+        }
+
+        .btn-sm {
+            padding: 0.5rem 1rem;
+            font-size: 0.875rem;
+        }
+
+        /* Main content */
+        main {
+            padding: 2rem 0;
+            min-height: calc(100vh - 80px);
+        }
+
+        /* Cards */
+        .card {
+            background: var(--bg-secondary);
+            border-radius: 1rem;
+            padding: 2rem;
+            border: 1px solid var(--border);
+        }
+
+        .card-header {
+            margin-bottom: 1.5rem;
+        }
+
+        .card-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .card-subtitle {
+            color: var(--text-secondary);
+        }
+
+        /* Forms */
+        .form-group {
+            margin-bottom: 1.5rem;
+        }
+
+        .form-group label {
+            display: block;
+            margin-bottom: 0.5rem;
+            font-weight: 500;
+            color: var(--text-secondary);
+        }
+
+        .form-control {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+            font-size: 1rem;
+            transition: border-color 0.2s;
+        }
+
+        .form-control:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+
+        /* Alerts */
+        .alert {
+            padding: 1rem 1.5rem;
+            border-radius: 0.5rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .alert-error {
+            background: rgba(239, 68, 68, 0.1);
+            border: 1px solid var(--error);
+            color: var(--error);
+        }
+
+        .alert-success {
+            background: rgba(34, 197, 94, 0.1);
+            border: 1px solid var(--success);
+            color: var(--success);
+        }
+
+        /* Grid */
+        .grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+
+        .grid-2 {
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        }
+
+        .grid-4 {
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        }
+
+        /* Sidebar layout */
+        .layout-sidebar {
+            display: grid;
+            grid-template-columns: 250px 1fr;
+            gap: 2rem;
+        }
+
+        @media (max-width: 768px) {
+            .layout-sidebar {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .sidebar {
+            background: var(--bg-secondary);
+            border-radius: 1rem;
+            padding: 1.5rem;
+            border: 1px solid var(--border);
+            height: fit-content;
+        }
+
+        .sidebar-nav {
+            list-style: none;
+        }
+
+        .sidebar-nav li {
+            margin-bottom: 0.5rem;
+        }
+
+        .sidebar-nav a {
+            display: block;
+            padding: 0.75rem 1rem;
+            color: var(--text-secondary);
+            text-decoration: none;
+            border-radius: 0.5rem;
+            transition: all 0.2s;
+        }
+
+        .sidebar-nav a:hover {
+            background: var(--bg-tertiary);
+            color: var(--text-primary);
+        }
+
+        .sidebar-nav a.active {
+            background: var(--accent);
+            color: white;
+        }
+
+        /* Utility */
+        .text-center {
+            text-align: center;
+        }
+
+        .mt-2 {
+            margin-top: 2rem;
+        }
+
+        .mb-1 {
+            margin-bottom: 1rem;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="container">
+            <a href="/" class="logo">AuthX</a>
+            <div class="nav-links">
+                {% if user %}
+                    <a href="/dashboard" {% if request.url.path == '/dashboard' %}class="active"{% endif %}>Dashboard</a>
+                    <a href="/process" {% if '/process' in request.url.path or '/route' in request.url.path %}class="active"{% endif %}>Process</a>
+                    <div class="user-info">
+                        <span class="user-badge">{{ user.name }} ({{ user.role }})</span>
+                        <form action="/logout" method="post" style="display: inline;">
+                            <button type="submit" class="btn btn-secondary btn-sm">Logout</button>
+                        </form>
+                    </div>
+                {% else %}
+                    <a href="/login" class="btn btn-primary btn-sm">Login</a>
+                {% endif %}
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <div class="container">
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+</body>
+</html>

--- a/examples/examples/templates/jinja2/dashboard.html
+++ b/examples/examples/templates/jinja2/dashboard.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard - AuthX Jinja2 Example{% endblock %}
+
+{% block content %}
+<div class="card mb-1">
+    <div class="card-header">
+        <h1 class="card-title">Dashboard</h1>
+        <p class="card-subtitle">Welcome back, {{ user.name }}!</p>
+    </div>
+
+    <div class="grid grid-2">
+        <div style="background: var(--bg-tertiary); padding: 1.5rem; border-radius: 0.5rem;">
+            <h4 style="color: var(--text-secondary); margin-bottom: 0.5rem;">Username</h4>
+            <p style="font-size: 1.25rem;">{{ user.username }}</p>
+        </div>
+        <div style="background: var(--bg-tertiary); padding: 1.5rem; border-radius: 0.5rem;">
+            <h4 style="color: var(--text-secondary); margin-bottom: 0.5rem;">Role</h4>
+            <p style="font-size: 1.25rem;">{{ user.role | capitalize }}</p>
+        </div>
+    </div>
+</div>
+
+<h2 style="margin-bottom: 1rem;">Quick Actions</h2>
+
+<div class="grid grid-4">
+    <a href="/route1" class="card" style="text-decoration: none; transition: transform 0.2s;">
+        <h3 style="color: var(--accent); margin-bottom: 0.5rem;">📊 Route 1</h3>
+        <p style="color: var(--text-secondary); font-size: 0.875rem;">Data Processing</p>
+    </a>
+
+    <a href="/route2" class="card" style="text-decoration: none; transition: transform 0.2s;">
+        <h3 style="color: var(--accent); margin-bottom: 0.5rem;">📈 Route 2</h3>
+        <p style="color: var(--text-secondary); font-size: 0.875rem;">Reports</p>
+    </a>
+
+    <a href="/route3" class="card" style="text-decoration: none; transition: transform 0.2s;">
+        <h3 style="color: var(--accent); margin-bottom: 0.5rem;">⚙️ Route 3</h3>
+        <p style="color: var(--text-secondary); font-size: 0.875rem;">Settings</p>
+    </a>
+
+    <a href="/route4" class="card" style="text-decoration: none; transition: transform 0.2s;">
+        <h3 style="color: var(--accent); margin-bottom: 0.5rem;">📉 Route 4</h3>
+        <p style="color: var(--text-secondary); font-size: 0.875rem;">Analytics</p>
+    </a>
+</div>
+
+<div class="card mt-2">
+    <div class="card-header">
+        <h3 class="card-title">How It Works</h3>
+    </div>
+    <p style="color: var(--text-secondary); margin-bottom: 1rem;">
+        This dashboard is a <strong>protected route</strong>. When you logged in:
+    </p>
+    <ol style="color: var(--text-secondary); padding-left: 1.5rem;">
+        <li style="margin-bottom: 0.5rem;">Your credentials were validated on the server</li>
+        <li style="margin-bottom: 0.5rem;">An access token was created and stored in an HTTP-only cookie</li>
+        <li style="margin-bottom: 0.5rem;">A CSRF token was also set in a cookie (readable by JavaScript)</li>
+        <li style="margin-bottom: 0.5rem;">You were redirected to this dashboard</li>
+    </ol>
+    <p style="color: var(--text-secondary); margin-top: 1rem;">
+        Every request to protected routes automatically includes the cookie. If not authenticated,
+        you'll be redirected to the login page.
+    </p>
+</div>
+{% endblock %}

--- a/examples/examples/templates/jinja2/home.html
+++ b/examples/examples/templates/jinja2/home.html
@@ -1,0 +1,89 @@
+{% extends "base.html" %}
+
+{% block title %}Home - AuthX Jinja2 Example{% endblock %}
+
+{% block content %}
+<div class="text-center" style="padding: 4rem 0;">
+    <h1 style="font-size: 3rem; margin-bottom: 1rem;">
+        Welcome to <span style="color: var(--accent);">AuthX</span>
+    </h1>
+    <p style="font-size: 1.25rem; color: var(--text-secondary); max-width: 600px; margin: 0 auto 2rem;">
+        A demonstration of AuthX authentication with Jinja2 templates for
+        server-side rendered web applications.
+    </p>
+
+    {% if user %}
+        <p style="margin-bottom: 2rem;">
+            Welcome back, <strong>{{ user.name }}</strong>!
+        </p>
+        <a href="/dashboard" class="btn btn-primary">Go to Dashboard</a>
+    {% else %}
+        <a href="/login" class="btn btn-primary" style="margin-right: 1rem;">Login</a>
+        <a href="#features" class="btn btn-secondary">Learn More</a>
+    {% endif %}
+</div>
+
+<div id="features" class="grid grid-2 mt-2">
+    <div class="card">
+        <div class="card-header">
+            <h3 class="card-title">🔐 Cookie-Based Auth</h3>
+        </div>
+        <p style="color: var(--text-secondary);">
+            Tokens are stored in HTTP-only cookies for secure, automatic authentication
+            on every request. Perfect for traditional web applications.
+        </p>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h3 class="card-title">🛡️ CSRF Protection</h3>
+        </div>
+        <p style="color: var(--text-secondary);">
+            Built-in CSRF protection for form submissions. AuthX automatically
+            generates and validates CSRF tokens.
+        </p>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h3 class="card-title">🔄 Redirect Flow</h3>
+        </div>
+        <p style="color: var(--text-secondary);">
+            Traditional login/logout flow with redirects instead of JSON responses.
+            Unauthenticated users are redirected to the login page.
+        </p>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h3 class="card-title">📄 Jinja2 Templates</h3>
+        </div>
+        <p style="color: var(--text-secondary);">
+            Server-side rendering with Jinja2 templates. User context is
+            passed to templates for personalized content.
+        </p>
+    </div>
+</div>
+
+<div class="card mt-2">
+    <div class="card-header">
+        <h3 class="card-title">Test Credentials</h3>
+    </div>
+    <div class="grid grid-2">
+        <div>
+            <h4 style="margin-bottom: 0.5rem;">Admin User</h4>
+            <p style="color: var(--text-secondary);">
+                Username: <code style="background: var(--bg-tertiary); padding: 0.25rem 0.5rem; border-radius: 0.25rem;">admin</code><br>
+                Password: <code style="background: var(--bg-tertiary); padding: 0.25rem 0.5rem; border-radius: 0.25rem;">admin123</code>
+            </p>
+        </div>
+        <div>
+            <h4 style="margin-bottom: 0.5rem;">Regular User</h4>
+            <p style="color: var(--text-secondary);">
+                Username: <code style="background: var(--bg-tertiary); padding: 0.25rem 0.5rem; border-radius: 0.25rem;">user</code><br>
+                Password: <code style="background: var(--bg-tertiary); padding: 0.25rem 0.5rem; border-radius: 0.25rem;">user123</code>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/examples/examples/templates/jinja2/login.html
+++ b/examples/examples/templates/jinja2/login.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+
+{% block title %}Login - AuthX Jinja2 Example{% endblock %}
+
+{% block content %}
+<div style="max-width: 400px; margin: 4rem auto;">
+    <div class="card">
+        <div class="card-header text-center">
+            <h2 class="card-title">Welcome Back</h2>
+            <p class="card-subtitle">Sign in to your account</p>
+        </div>
+
+        {% if error %}
+        <div class="alert alert-error">
+            {{ error }}
+        </div>
+        {% endif %}
+
+        <form action="/login" method="post">
+            <!-- Hidden field to preserve redirect destination -->
+            <input type="hidden" name="next" value="{{ next }}">
+
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input
+                    type="text"
+                    id="username"
+                    name="username"
+                    class="form-control"
+                    placeholder="Enter your username"
+                    required
+                    autofocus
+                >
+            </div>
+
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    class="form-control"
+                    placeholder="Enter your password"
+                    required
+                >
+            </div>
+
+            <button type="submit" class="btn btn-primary" style="width: 100%;">
+                Sign In
+            </button>
+        </form>
+
+        <div class="text-center mt-2">
+            <p style="color: var(--text-secondary); font-size: 0.875rem;">
+                Test credentials: <code>admin</code> / <code>admin123</code>
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/examples/examples/templates/jinja2/process.html
+++ b/examples/examples/templates/jinja2/process.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+
+{% block title %}{{ current_route | capitalize }} - AuthX Jinja2 Example{% endblock %}
+
+{% block content %}
+<div class="layout-sidebar">
+    <!-- Sidebar Navigation -->
+    <aside class="sidebar">
+        <h3 style="margin-bottom: 1rem; color: var(--text-secondary); font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.05em;">
+            Navigation
+        </h3>
+        <ul class="sidebar-nav">
+            <li>
+                <a href="/process" {% if current_route == 'process' %}class="active"{% endif %}>
+                    📋 Process Home
+                </a>
+            </li>
+            <li>
+                <a href="/route1" {% if current_route == 'route1' %}class="active"{% endif %}>
+                    📊 Route 1 - Data
+                </a>
+            </li>
+            <li>
+                <a href="/route2" {% if current_route == 'route2' %}class="active"{% endif %}>
+                    📈 Route 2 - Reports
+                </a>
+            </li>
+            <li>
+                <a href="/route3" {% if current_route == 'route3' %}class="active"{% endif %}>
+                    ⚙️ Route 3 - Settings
+                </a>
+            </li>
+            <li>
+                <a href="/route4" {% if current_route == 'route4' %}class="active"{% endif %}>
+                    📉 Route 4 - Analytics
+                </a>
+            </li>
+        </ul>
+
+        <hr style="border: none; border-top: 1px solid var(--border); margin: 1.5rem 0;">
+
+        <a href="/dashboard" class="btn btn-secondary btn-sm" style="width: 100%; text-align: center;">
+            ← Back to Dashboard
+        </a>
+    </aside>
+
+    <!-- Main Content -->
+    <div>
+        {% if message %}
+        <div class="alert alert-success">
+            {{ message }}
+        </div>
+        {% endif %}
+
+        <div class="card">
+            <div class="card-header">
+                <h1 class="card-title">
+                    {% if current_route == 'process' %}
+                        Process Center
+                    {% elif current_route == 'route1' %}
+                        Data Processing
+                    {% elif current_route == 'route2' %}
+                        Reports
+                    {% elif current_route == 'route3' %}
+                        Settings
+                    {% elif current_route == 'route4' %}
+                        Analytics
+                    {% endif %}
+                </h1>
+                <p class="card-subtitle">
+                    You are viewing: <code style="background: var(--bg-tertiary); padding: 0.25rem 0.5rem; border-radius: 0.25rem;">/{{ current_route }}</code>
+                </p>
+            </div>
+
+            <p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+                This is a protected route. You can only see this because you're authenticated as
+                <strong>{{ user.name }}</strong>.
+            </p>
+
+            <!-- Example Form with CSRF Protection -->
+            <div style="background: var(--bg-tertiary); padding: 1.5rem; border-radius: 0.5rem;">
+                <h3 style="margin-bottom: 1rem;">Example Action (with CSRF)</h3>
+                <form action="/process/action" method="post">
+                    <!-- CSRF Token - Required for POST requests with cookie auth -->
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+                    <div class="form-group">
+                        <label for="action">Select Action</label>
+                        <select id="action" name="action" class="form-control">
+                            <option value="process_data">Process Data</option>
+                            <option value="generate_report">Generate Report</option>
+                            <option value="update_settings">Update Settings</option>
+                            <option value="run_analytics">Run Analytics</option>
+                        </select>
+                    </div>
+
+                    <button type="submit" class="btn btn-primary">
+                        Execute Action
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <div class="card mt-2">
+            <div class="card-header">
+                <h3 class="card-title">CSRF Protection Explained</h3>
+            </div>
+            <p style="color: var(--text-secondary); margin-bottom: 1rem;">
+                The form above includes a hidden <code>csrf_token</code> field. This is required for
+                POST/PUT/PATCH/DELETE requests when using cookie-based authentication.
+            </p>
+            <pre style="background: var(--bg-tertiary); padding: 1rem; border-radius: 0.5rem; overflow-x: auto; font-size: 0.875rem;">
+&lt;form action="/process/action" method="post"&gt;
+    &lt;!-- CSRF Token from cookie --&gt;
+    &lt;input type="hidden" name="csrf_token" value="<span style="color: var(--accent);">{{ csrf_token }}</span>"&gt;
+
+    &lt;!-- Your form fields --&gt;
+    &lt;button type="submit"&gt;Submit&lt;/button&gt;
+&lt;/form&gt;</pre>
+            <p style="color: var(--text-secondary); margin-top: 1rem;">
+                The CSRF token is set in a cookie (<code>csrf_access_token</code>) that JavaScript can read,
+                allowing you to include it in forms or AJAX requests.
+            </p>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,7 @@ nav:
     - Dependency Aliases: dependencies/aliases.md
     - Dependency Bundle: dependencies/bundle.md
   - Extra Features:
+    - Template Engines (Jinja2): extra/templates.md
     - Oauth2 Features: extra/OAuth2.md
     - Metrics Features: extra/Metrics.md
     - Cache Features: extra/Cache.md


### PR DESCRIPTION
Fixes #618 

- Introduced a new section in the documentation for using AuthX with Jinja2 template engines, detailing the differences from API authentication.
- Added comprehensive examples for login, logout, and protected routes using Jinja2 templates.
- Created a complete example application demonstrating cookie-based authentication and CSRF protection with Jinja2.
- Updated the navigation in mkdocs.yml to include the new template engines section.