### PR TITLE
✨ Implemented AuthManager + Policy Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ curl -H "Authorization: Bearer <your-token>" http://localhost:8000/protected
 - Access and refresh token support
 - Token freshness for sensitive operations
 - Token blocklist/revocation
+- Built-in `AuthManager` for isolated multi-login-type applications
+- Pluggable policy engine for scopes, attributes, environment checks, and custom evaluators
 - Extensible error handling
 
 ### Extra Features

--- a/authx/__init__.py
+++ b/authx/__init__.py
@@ -9,6 +9,9 @@ from authx.dependencies import AuthXDependency
 from authx.exceptions import (
     InsufficientScopeError,
     JWTDecodeError,
+    LoginTypeMismatchError,
+    PolicyDeniedError,
+    PolicyEvaluationError,
     RateLimitExceeded,
     TokenExpiredError,
     TokenInvalidAudienceError,
@@ -16,6 +19,14 @@ from authx.exceptions import (
     TokenInvalidSignatureError,
 )
 from authx.main import AuthX
+from authx.manager import AuthManager
+from authx.policy import (
+    PolicyCondition,
+    PolicyContext,
+    PolicyDecision,
+    PolicyEngine,
+    PolicyRule,
+)
 from authx.schema import RequestToken, TokenPayload, TokenResponse
 
 __all__ = (
@@ -24,9 +35,18 @@ __all__ = (
     "TokenPayload",
     "TokenResponse",
     "AuthX",
+    "AuthManager",
     "AuthXDependency",
     "InsufficientScopeError",
     "JWTDecodeError",
+    "LoginTypeMismatchError",
+    "PolicyDeniedError",
+    "PolicyEvaluationError",
+    "PolicyCondition",
+    "PolicyContext",
+    "PolicyDecision",
+    "PolicyEngine",
+    "PolicyRule",
     "TokenExpiredError",
     "TokenInvalidAudienceError",
     "TokenInvalidIssuerError",

--- a/authx/_internal/_error.py
+++ b/authx/_internal/_error.py
@@ -21,6 +21,9 @@ class _ErrorHandler:
     MSG_CSRFError = "CSRF double submit does not match"
     MSG_JWTDecodeError = "Invalid Token"
     MSG_InsufficientScopeError = None  # Use detailed exception message showing required vs provided scopes
+    MSG_LoginTypeMismatchError = None  # Use detailed exception message showing expected vs actual type
+    MSG_PolicyDeniedError = None  # Use detailed exception message
+    MSG_PolicyEvaluationError = "Policy evaluation failed"
 
     async def _rate_limit_handler(
         self,
@@ -62,13 +65,15 @@ class _ErrorHandler:
             # Use attribute message if available, otherwise use exception message
             message = attr_message if attr_message is not None else default_message
 
-        return JSONResponse(
-            status_code=status_code,
-            content={
-                "message": message,
-                "error_type": exc.__class__.__name__,
-            },
-        )
+        content = {
+            "message": message,
+            "error_type": exc.__class__.__name__,
+        }
+        if isinstance(exc, exceptions.LoginTypeMismatchError):
+            content["expected_type"] = exc.expected_type
+            content["actual_type"] = exc.actual_type
+
+        return JSONResponse(status_code=status_code, content=content)
 
     def _set_app_exception_handler(
         self,
@@ -112,6 +117,12 @@ class _ErrorHandler:
         )
         self._set_app_exception_handler(
             app,
+            exception=exceptions.LoginTypeMismatchError,
+            status_code=401,
+            message=None,
+        )
+        self._set_app_exception_handler(
+            app,
             exception=exceptions.RevokedTokenError,
             status_code=401,
             message=self.MSG_RevokedTokenError,
@@ -151,6 +162,18 @@ class _ErrorHandler:
             exception=exceptions.InsufficientScopeError,
             status_code=403,
             message=None,  # Use detailed exception message showing required vs provided scopes
+        )
+        self._set_app_exception_handler(
+            app,
+            exception=exceptions.PolicyDeniedError,
+            status_code=403,
+            message=None,
+        )
+        self._set_app_exception_handler(
+            app,
+            exception=exceptions.PolicyEvaluationError,
+            status_code=500,
+            message=self.MSG_PolicyEvaluationError,
         )
         self._set_app_exception_handler(
             app,

--- a/authx/exceptions.py
+++ b/authx/exceptions.py
@@ -81,6 +81,30 @@ class TokenTypeError(TokenError):
     pass
 
 
+class LoginTypeMismatchError(TokenTypeError):
+    """Exception raised when a token belongs to a different login type."""
+
+    def __init__(
+        self,
+        expected_type: str,
+        actual_type: Optional[str] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        """Initialize LoginTypeMismatchError.
+
+        Args:
+            expected_type: Login type required by the protected endpoint.
+            actual_type: Login type found in the token, if it could be determined.
+            message: Optional custom error message.
+        """
+        self.expected_type = expected_type
+        self.actual_type = actual_type
+        actual = actual_type if actual_type is not None else "unknown"
+        if message is None:
+            message = f"Token type mismatch: expected '{expected_type}', got '{actual}'"
+        super().__init__(message)
+
+
 class RevokedTokenError(TokenError):
     """Exception raised when a revoked token has been used."""
 
@@ -137,6 +161,25 @@ class InsufficientScopeError(TokenError):
         if message is None:
             message = f"Missing required scopes: {required}. Provided: {self.provided}"
         super().__init__(message)
+
+
+class PolicyDeniedError(TokenError):
+    """Exception raised when a policy evaluation denies access."""
+
+    def __init__(self, reason: str = "Policy denied access") -> None:
+        """Initialize PolicyDeniedError.
+
+        Args:
+            reason: Human-readable reason for the denial.
+        """
+        self.reason = reason
+        super().__init__(reason)
+
+
+class PolicyEvaluationError(AuthXException):
+    """Exception raised when a policy evaluator cannot be evaluated."""
+
+    pass
 
 
 class RateLimitExceeded(AuthXException):

--- a/authx/exceptions.py
+++ b/authx/exceptions.py
@@ -1,12 +1,14 @@
 """Exceptions for AuthX."""
 
-from typing import Optional
+from typing import Any, Optional
 
 
 class AuthXException(Exception):
     """Base AuthXException Exception."""
 
-    pass
+    def __init__(self, *args: Any, login_type: Optional[str] = None, **kwargs: Any) -> None:
+        self.login_type = login_type
+        super().__init__(*args)
 
 
 class BadConfigurationError(AuthXException):
@@ -85,10 +87,11 @@ class LoginTypeMismatchError(TokenTypeError):
     """Exception raised when a token belongs to a different login type."""
 
     def __init__(
-        self,
-        expected_type: str,
-        actual_type: Optional[str] = None,
-        message: Optional[str] = None,
+            self,
+            expected_type: str,
+            actual_type: Optional[str] = None,
+            message: Optional[str] = None,
+            login_type: Optional[str] = None,
     ) -> None:
         """Initialize LoginTypeMismatchError.
 
@@ -96,13 +99,14 @@ class LoginTypeMismatchError(TokenTypeError):
             expected_type: Login type required by the protected endpoint.
             actual_type: Login type found in the token, if it could be determined.
             message: Optional custom error message.
+            login_type: The login_type to set on the base exception.
         """
         self.expected_type = expected_type
         self.actual_type = actual_type
         actual = actual_type if actual_type is not None else "unknown"
         if message is None:
             message = f"Token type mismatch: expected '{expected_type}', got '{actual}'"
-        super().__init__(message)
+        super().__init__(message, login_type=login_type)
 
 
 class RevokedTokenError(TokenError):
@@ -144,10 +148,11 @@ class InsufficientScopeError(TokenError):
     """
 
     def __init__(
-        self,
-        required: list[str],
-        provided: Optional[list[str]] = None,
-        message: Optional[str] = None,
+            self,
+            required: list[str],
+            provided: Optional[list[str]] = None,
+            message: Optional[str] = None,
+            login_type: Optional[str] = None,
     ) -> None:
         """Initialize InsufficientScopeError.
 
@@ -155,25 +160,27 @@ class InsufficientScopeError(TokenError):
             required: List of scopes that were required.
             provided: List of scopes that were provided in the token.
             message: Optional custom error message.
+            login_type: The login_type to set on the base exception.
         """
         self.required = required
         self.provided = provided or []
         if message is None:
             message = f"Missing required scopes: {required}. Provided: {self.provided}"
-        super().__init__(message)
+        super().__init__(message, login_type=login_type)
 
 
 class PolicyDeniedError(TokenError):
     """Exception raised when a policy evaluation denies access."""
 
-    def __init__(self, reason: str = "Policy denied access") -> None:
+    def __init__(self, reason: str = "Policy denied access", login_type: Optional[str] = None) -> None:
         """Initialize PolicyDeniedError.
 
         Args:
             reason: Human-readable reason for the denial.
+            login_type: The login_type to set on the base exception.
         """
         self.reason = reason
-        super().__init__(reason)
+        super().__init__(reason, login_type=login_type)
 
 
 class PolicyEvaluationError(AuthXException):

--- a/authx/exceptions.py
+++ b/authx/exceptions.py
@@ -87,11 +87,11 @@ class LoginTypeMismatchError(TokenTypeError):
     """Exception raised when a token belongs to a different login type."""
 
     def __init__(
-            self,
-            expected_type: str,
-            actual_type: Optional[str] = None,
-            message: Optional[str] = None,
-            login_type: Optional[str] = None,
+        self,
+        expected_type: str,
+        actual_type: Optional[str] = None,
+        message: Optional[str] = None,
+        login_type: Optional[str] = None,
     ) -> None:
         """Initialize LoginTypeMismatchError.
 
@@ -148,11 +148,11 @@ class InsufficientScopeError(TokenError):
     """
 
     def __init__(
-            self,
-            required: list[str],
-            provided: Optional[list[str]] = None,
-            message: Optional[str] = None,
-            login_type: Optional[str] = None,
+        self,
+        required: list[str],
+        provided: Optional[list[str]] = None,
+        message: Optional[str] = None,
+        login_type: Optional[str] = None,
     ) -> None:
         """Initialize InsufficientScopeError.
 

--- a/authx/main.py
+++ b/authx/main.py
@@ -182,26 +182,31 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
         issuer: Optional[str] = None,
     ) -> TokenPayload:
         try:
-            return TokenPayload.decode(
-                token=token,
-                key=self.config.public_key,
-                algorithms=[self.config.JWT_ALGORITHM],
-                verify=verify,
-                audience=audience or self.config.JWT_DECODE_AUDIENCE,
-                issuer=issuer or self.config.JWT_DECODE_ISSUER,
-            )
-        except JWTDecodeError:
-            previous_key = self.config.previous_public_key
-            if previous_key is None:
-                raise
-            return TokenPayload.decode(
-                token=token,
-                key=previous_key,
-                algorithms=[self.config.JWT_ALGORITHM],
-                verify=verify,
-                audience=audience or self.config.JWT_DECODE_AUDIENCE,
-                issuer=issuer or self.config.JWT_DECODE_ISSUER,
-            )
+            try:
+                return TokenPayload.decode(
+                    token=token,
+                    key=self.config.public_key,
+                    algorithms=[self.config.JWT_ALGORITHM],
+                    verify=verify,
+                    audience=audience or self.config.JWT_DECODE_AUDIENCE,
+                    issuer=issuer or self.config.JWT_DECODE_ISSUER,
+                )
+            except JWTDecodeError:
+                previous_key = self.config.previous_public_key
+                if previous_key is None:
+                    raise
+                return TokenPayload.decode(
+                    token=token,
+                    key=previous_key,
+                    algorithms=[self.config.JWT_ALGORITHM],
+                    verify=verify,
+                    audience=audience or self.config.JWT_DECODE_AUDIENCE,
+                    issuer=issuer or self.config.JWT_DECODE_ISSUER,
+                )
+        except AuthXException as e:
+            if e.login_type is None:
+                e.login_type = self.login_type
+            raise
 
     def _set_cookies(
         self,
@@ -384,7 +389,7 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
         )
 
         if await self.is_token_in_blocklist(request_token.token):
-            raise RevokedTokenError("Token has been revoked")
+            raise RevokedTokenError("Token has been revoked", login_type=self.login_type)
 
         return self.verify_token(
             request_token,
@@ -415,28 +420,33 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
             TokenPayload: Verified token payload
         """
         try:
-            return token.verify(
-                key=self.config.public_key,
-                algorithms=[self.config.JWT_ALGORITHM],
-                verify_fresh=verify_fresh,
-                verify_type=verify_type,
-                verify_csrf=verify_csrf,
-                audience=self.config.JWT_DECODE_AUDIENCE,
-                issuer=self.config.JWT_DECODE_ISSUER,
-            )
-        except JWTDecodeError:
-            previous_key = self.config.previous_public_key
-            if previous_key is None:
-                raise
-            return token.verify(
-                key=previous_key,
-                algorithms=[self.config.JWT_ALGORITHM],
-                verify_fresh=verify_fresh,
-                verify_type=verify_type,
-                verify_csrf=verify_csrf,
-                audience=self.config.JWT_DECODE_AUDIENCE,
-                issuer=self.config.JWT_DECODE_ISSUER,
-            )
+            try:
+                return token.verify(
+                    key=self.config.public_key,
+                    algorithms=[self.config.JWT_ALGORITHM],
+                    verify_fresh=verify_fresh,
+                    verify_type=verify_type,
+                    verify_csrf=verify_csrf,
+                    audience=self.config.JWT_DECODE_AUDIENCE,
+                    issuer=self.config.JWT_DECODE_ISSUER,
+                )
+            except JWTDecodeError:
+                previous_key = self.config.previous_public_key
+                if previous_key is None:
+                    raise
+                return token.verify(
+                    key=previous_key,
+                    algorithms=[self.config.JWT_ALGORITHM],
+                    verify_fresh=verify_fresh,
+                    verify_type=verify_type,
+                    verify_csrf=verify_csrf,
+                    audience=self.config.JWT_DECODE_AUDIENCE,
+                    issuer=self.config.JWT_DECODE_ISSUER,
+                )
+        except AuthXException as e:
+            if e.login_type is None:
+                e.login_type = self.login_type
+            raise
 
     def create_access_token(
         self,
@@ -724,12 +734,13 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
         if token_str is None:
             raise MissingTokenError(
                 f"Missing token in WebSocket query parameter '{self.config.JWT_QUERY_STRING_NAME}' "
-                f"or '{self.config.JWT_HEADER_NAME}' header"
+                f"or '{self.config.JWT_HEADER_NAME}' header",
+                login_type=self.login_type,
             )
 
         request_token = RequestToken(token=token_str, csrf=None, type="access", location="query")
         if await self.is_token_in_blocklist(request_token.token):
-            raise RevokedTokenError("Token has been revoked")
+            raise RevokedTokenError("Token has been revoked", login_type=self.login_type)
         return self.verify_token(request_token, verify_type=True, verify_fresh=False, verify_csrf=False)
 
     def get_dependency(self, request: Request, response: Response) -> AuthXDependency[Any]:
@@ -877,7 +888,11 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
             )
 
             if not has_required_scopes(required_scopes, payload.scopes, all_required=all_required):
-                raise InsufficientScopeError(required=required_scopes, provided=payload.scopes)
+                raise InsufficientScopeError(
+                    required=required_scopes,
+                    provided=payload.scopes,
+                    login_type=self.login_type,
+                )
 
             return payload
 

--- a/authx/main.py
+++ b/authx/main.py
@@ -56,18 +56,25 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
 
     """
 
-    def __init__(self, config: AuthXConfig = AuthXConfig(), model: Optional[T] = None) -> None:
+    def __init__(
+        self,
+        config: AuthXConfig = AuthXConfig(),
+        model: Optional[T] = None,
+        login_type: Optional[str] = None,
+    ) -> None:
         """AuthX base object.
 
         Args:
             config (AuthXConfig, optional): Configuration instance to use. Defaults to AuthXConfig().
             model (Optional[T], optional): Model type hint. Defaults to dict[str, Any].
+            login_type (Optional[str], optional): Explicit login type for manager-based auth contexts.
         """
         self.model: Union[T, dict[str, Any]] = model if model is not None else {}
         super().__init__(model=model)
         super(_CallbackHandler, self).__init__()
         self._config = config
         self._session_store: Optional[Any] = None
+        self.login_type = login_type
 
     def load_config(self, config: AuthXConfig) -> None:
         """Load and store the configuration for the authentication system.
@@ -105,6 +112,10 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
         # Handle additional data
         if data is None:
             data = {}
+        elif self.login_type is not None:
+            data = data.copy()
+        if self.login_type is not None:
+            data["login_type"] = self.login_type
         # Handle expiry date
         exp = expiry
         if exp is None:
@@ -143,6 +154,9 @@ class AuthX(_CallbackHandler[T], _ErrorHandler):
         scopes: Optional[list[str]] = None,
         **kwargs: Any,
     ) -> str:
+        if self.login_type is not None:
+            data = data.copy() if data is not None else {}
+            data["login_type"] = self.login_type
         payload = self._create_payload(
             uid=uid,
             type=type,

--- a/authx/manager.py
+++ b/authx/manager.py
@@ -1,0 +1,305 @@
+"""AuthManager for multiple isolated AuthX contexts."""
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any, Optional
+
+from fastapi import FastAPI, Request
+
+from authx.config import AuthXConfig
+from authx.exceptions import (
+    BadConfigurationError,
+    JWTDecodeError,
+    LoginTypeMismatchError,
+    PolicyDeniedError,
+    RevokedTokenError,
+)
+from authx.main import AuthX
+from authx.policy import (
+    PolicyContext,
+    PolicyEngine,
+    PolicyEvaluator,
+    PolicyRule,
+    build_policy_environment,
+    default_subject_from_payload,
+)
+from authx.schema import RequestToken, TokenPayload, TokenResponse
+from authx.types import DateTimeExpression, StringOrSequence, TokenLocations
+
+
+class AuthManager:
+    """Manage multiple isolated AuthX instances by login type."""
+
+    def __init__(
+        self,
+        policy_engine: Optional[PolicyEngine] = None,
+        policy_rules: Optional[Sequence[PolicyRule]] = None,
+    ) -> None:
+        """Initialize AuthManager.
+
+        Args:
+            policy_engine: Optional policy engine instance.
+            policy_rules: Optional rules used when creating the default policy engine.
+        """
+        self._auth_by_type: dict[str, AuthX[Any]] = {}
+        self.policy_engine = policy_engine or PolicyEngine(rules=policy_rules)
+
+    @property
+    def login_types(self) -> tuple[str, ...]:
+        """Return registered login types."""
+        return tuple(self._auth_by_type)
+
+    def register(self, auth: AuthX[Any]) -> None:
+        """Register an AuthX instance with a unique login type."""
+        if auth.login_type is None:
+            raise BadConfigurationError("AuthX instances registered with AuthManager require a login_type")
+        if auth.login_type in self._auth_by_type:
+            raise BadConfigurationError(f"AuthX login_type '{auth.login_type}' is already registered")
+        self._auth_by_type[auth.login_type] = auth
+
+    def get(self, login_type: str) -> AuthX[Any]:
+        """Return the AuthX instance for a login type."""
+        try:
+            return self._auth_by_type[login_type]
+        except KeyError as e:
+            raise BadConfigurationError(f"Unknown login_type '{login_type}'") from e
+
+    def handle_errors(self, app: FastAPI) -> None:
+        """Register AuthX error handlers on a FastAPI application."""
+        if self._auth_by_type:
+            next(iter(self._auth_by_type.values())).handle_errors(app)
+        else:
+            AuthX(config=AuthXConfig(JWT_SECRET_KEY="authmanager-error-handler")).handle_errors(app)
+
+    def add_policy_rule(self, rule: PolicyRule) -> None:
+        """Register a policy rule."""
+        self.policy_engine.add_rule(rule)
+
+    def add_policy_evaluator(self, evaluator: PolicyEvaluator) -> None:
+        """Register a global policy evaluator."""
+        self.policy_engine.add_evaluator(evaluator)
+
+    def create_access_token(
+        self,
+        login_type: str,
+        uid: str,
+        fresh: bool = False,
+        headers: Optional[dict[str, Any]] = None,
+        expiry: Optional[DateTimeExpression] = None,
+        data: Optional[dict[str, Any]] = None,
+        audience: Optional[StringOrSequence] = None,
+        scopes: Optional[list[str]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        """Create an access token for a registered login type."""
+        auth = self.get(login_type)
+        return auth.create_access_token(uid, fresh, headers, expiry, data, audience, scopes, *args, **kwargs)
+
+    def create_refresh_token(
+        self,
+        login_type: str,
+        uid: str,
+        headers: Optional[dict[str, Any]] = None,
+        expiry: Optional[DateTimeExpression] = None,
+        data: Optional[dict[str, Any]] = None,
+        audience: Optional[StringOrSequence] = None,
+        scopes: Optional[list[str]] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> str:
+        """Create a refresh token for a registered login type."""
+        auth = self.get(login_type)
+        return auth.create_refresh_token(uid, headers, expiry, data, audience, scopes, *args, **kwargs)
+
+    def create_token_pair(
+        self,
+        login_type: str,
+        uid: str,
+        fresh: bool = False,
+        headers: Optional[dict[str, Any]] = None,
+        access_expiry: Optional[DateTimeExpression] = None,
+        refresh_expiry: Optional[DateTimeExpression] = None,
+        data: Optional[dict[str, Any]] = None,
+        audience: Optional[StringOrSequence] = None,
+        access_scopes: Optional[list[str]] = None,
+        refresh_scopes: Optional[list[str]] = None,
+    ) -> TokenResponse:
+        """Create access and refresh tokens for a registered login type."""
+        return self.get(login_type).create_token_pair(
+            uid=uid,
+            fresh=fresh,
+            headers=headers,
+            access_expiry=access_expiry,
+            refresh_expiry=refresh_expiry,
+            data=data,
+            audience=audience,
+            access_scopes=access_scopes,
+            refresh_scopes=refresh_scopes,
+        )
+
+    def token_required(
+        self,
+        login_type: str,
+        type: str = "access",
+        verify_type: bool = True,
+        verify_fresh: bool = False,
+        verify_csrf: Optional[bool] = None,
+        locations: Optional[TokenLocations] = None,
+    ) -> Callable[[Request], Awaitable[TokenPayload]]:
+        """Dependency factory requiring a token for a specific login type."""
+
+        async def _auth_required(request: Request) -> TokenPayload:
+            return await self._auth_required(
+                login_type=login_type,
+                request=request,
+                type=type,
+                verify_type=verify_type,
+                verify_fresh=verify_fresh,
+                verify_csrf=verify_csrf,
+                locations=locations,
+            )
+
+        return _auth_required
+
+    def access_token_required(self, login_type: str) -> Callable[[Request], Awaitable[TokenPayload]]:
+        """Dependency factory requiring an access token for a login type."""
+        return self.token_required(login_type=login_type, type="access")
+
+    def refresh_token_required(self, login_type: str) -> Callable[[Request], Awaitable[TokenPayload]]:
+        """Dependency factory requiring a refresh token for a login type."""
+        return self.token_required(login_type=login_type, type="refresh")
+
+    def fresh_token_required(self, login_type: str) -> Callable[[Request], Awaitable[TokenPayload]]:
+        """Dependency factory requiring a fresh access token for a login type."""
+        return self.token_required(login_type=login_type, type="access", verify_fresh=True)
+
+    async def _auth_required(
+        self,
+        login_type: str,
+        request: Request,
+        type: str = "access",
+        verify_type: bool = True,
+        verify_fresh: bool = False,
+        verify_csrf: Optional[bool] = None,
+        locations: Optional[TokenLocations] = None,
+    ) -> TokenPayload:
+        auth = self.get(login_type)
+        try:
+            payload = await auth._auth_required(
+                request=request,
+                type=type,
+                verify_type=verify_type,
+                verify_fresh=verify_fresh,
+                verify_csrf=verify_csrf,
+                locations=locations,
+            )
+        except JWTDecodeError:
+            mismatch = await self._decode_mismatched_login_type(
+                expected_login_type=login_type,
+                request=request,
+                type=type,
+                locations=locations,
+            )
+            if mismatch is not None:
+                raise LoginTypeMismatchError(expected_type=login_type, actual_type=mismatch) from None
+            raise
+
+        self._verify_login_type(payload, login_type)
+        return payload
+
+    async def _decode_mismatched_login_type(
+        self,
+        expected_login_type: str,
+        request: Request,
+        type: str,
+        locations: Optional[TokenLocations],
+    ) -> Optional[str]:
+        expected_auth = self.get(expected_login_type)
+        request_token = await expected_auth.get_token_from_request(
+            request=request,
+            type="refresh" if type == "refresh" else "access",
+            optional=False,
+            locations=locations,
+        )
+        for registered_type, auth in self._auth_by_type.items():
+            if registered_type == expected_login_type:
+                continue
+            payload = self._try_verify_with_auth(auth, request_token)
+            if payload is not None:
+                return self._payload_login_type(payload)
+        return None
+
+    def _try_verify_with_auth(self, auth: AuthX[Any], request_token: RequestToken) -> Optional[TokenPayload]:
+        try:
+            return auth.verify_token(request_token, verify_csrf=False)
+        except (JWTDecodeError, RevokedTokenError):
+            return None
+
+    def _verify_login_type(self, payload: TokenPayload, expected_login_type: str) -> None:
+        actual_login_type = self._payload_login_type(payload)
+        if actual_login_type != expected_login_type:
+            raise LoginTypeMismatchError(expected_type=expected_login_type, actual_type=actual_login_type)
+
+    def _payload_login_type(self, payload: TokenPayload) -> Optional[str]:
+        login_type = payload.login_type
+        return str(login_type) if login_type is not None else None
+
+    async def authorize(
+        self,
+        login_type: str,
+        action: str,
+        resource: str,
+        *,
+        payload: Optional[TokenPayload] = None,
+        request: Optional[Request] = None,
+        subject: Any = None,
+        resource_attrs: Any = None,
+        env: Optional[Mapping[str, Any]] = None,
+    ) -> TokenPayload:
+        """Authorize a token payload against the policy engine."""
+        if payload is None:
+            if request is None:
+                raise PolicyDeniedError("A request or token payload is required for policy authorization")
+            payload = await self._auth_required(login_type=login_type, request=request)
+        else:
+            self._verify_login_type(payload, login_type)
+
+        context = PolicyContext(
+            login_type=login_type,
+            action=action,
+            resource=resource,
+            payload=payload,
+            request=request,
+            subject=subject if subject is not None else default_subject_from_payload(payload),
+            resource_attrs=resource_attrs or {},
+            environment=build_policy_environment(request=request, environment=env),
+        )
+        decision = await self.policy_engine.evaluate(context)
+        if not decision.allowed:
+            raise PolicyDeniedError(decision.reason)
+        return payload
+
+    def policy_required(
+        self,
+        login_type: str,
+        action: str,
+        resource: str,
+        *,
+        subject: Any = None,
+        resource_attrs: Any = None,
+        env: Optional[Mapping[str, Any]] = None,
+    ) -> Callable[[Request], Awaitable[TokenPayload]]:
+        """Dependency factory requiring policy authorization."""
+
+        async def _policy_required(request: Request) -> TokenPayload:
+            return await self.authorize(
+                login_type=login_type,
+                action=action,
+                resource=resource,
+                request=request,
+                subject=subject,
+                resource_attrs=resource_attrs,
+                env=env,
+            )
+
+        return _policy_required

--- a/authx/manager.py
+++ b/authx/manager.py
@@ -3,10 +3,9 @@
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from typing import Any, Optional
 
-from fastapi import FastAPI, Request
+from fastapi import Request
 
 from authx._internal._error import _ErrorHandler
-from authx.config import AuthXConfig
 from authx.exceptions import (
     BadConfigurationError,
     JWTDecodeError,
@@ -63,7 +62,6 @@ class AuthManager(_ErrorHandler):
             return self._auth_by_type[login_type]
         except KeyError as e:
             raise BadConfigurationError(f"Unknown login_type '{login_type}'") from e
-
 
     def add_policy_rule(self, rule: PolicyRule) -> None:
         """Register a policy rule."""
@@ -196,7 +194,9 @@ class AuthManager(_ErrorHandler):
                 locations=locations,
             )
             if mismatch is not None:
-                raise LoginTypeMismatchError(expected_type=login_type, actual_type=mismatch, login_type=login_type) from None
+                raise LoginTypeMismatchError(
+                    expected_type=login_type, actual_type=mismatch, login_type=login_type
+                ) from None
             raise
 
         self._verify_login_type(payload, login_type)

--- a/authx/manager.py
+++ b/authx/manager.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 
 from fastapi import FastAPI, Request
 
+from authx._internal._error import _ErrorHandler
 from authx.config import AuthXConfig
 from authx.exceptions import (
     BadConfigurationError,
@@ -26,7 +27,7 @@ from authx.schema import RequestToken, TokenPayload, TokenResponse
 from authx.types import DateTimeExpression, StringOrSequence, TokenLocations
 
 
-class AuthManager:
+class AuthManager(_ErrorHandler):
     """Manage multiple isolated AuthX instances by login type."""
 
     def __init__(
@@ -63,12 +64,6 @@ class AuthManager:
         except KeyError as e:
             raise BadConfigurationError(f"Unknown login_type '{login_type}'") from e
 
-    def handle_errors(self, app: FastAPI) -> None:
-        """Register AuthX error handlers on a FastAPI application."""
-        if self._auth_by_type:
-            next(iter(self._auth_by_type.values())).handle_errors(app)
-        else:
-            AuthX(config=AuthXConfig(JWT_SECRET_KEY="authmanager-error-handler")).handle_errors(app)
 
     def add_policy_rule(self, rule: PolicyRule) -> None:
         """Register a policy rule."""
@@ -201,7 +196,7 @@ class AuthManager:
                 locations=locations,
             )
             if mismatch is not None:
-                raise LoginTypeMismatchError(expected_type=login_type, actual_type=mismatch) from None
+                raise LoginTypeMismatchError(expected_type=login_type, actual_type=mismatch, login_type=login_type) from None
             raise
 
         self._verify_login_type(payload, login_type)
@@ -238,7 +233,11 @@ class AuthManager:
     def _verify_login_type(self, payload: TokenPayload, expected_login_type: str) -> None:
         actual_login_type = self._payload_login_type(payload)
         if actual_login_type != expected_login_type:
-            raise LoginTypeMismatchError(expected_type=expected_login_type, actual_type=actual_login_type)
+            raise LoginTypeMismatchError(
+                expected_type=expected_login_type,
+                actual_type=actual_login_type,
+                login_type=expected_login_type,
+            )
 
     def _payload_login_type(self, payload: TokenPayload) -> Optional[str]:
         login_type = payload.login_type
@@ -259,7 +258,10 @@ class AuthManager:
         """Authorize a token payload against the policy engine."""
         if payload is None:
             if request is None:
-                raise PolicyDeniedError("A request or token payload is required for policy authorization")
+                raise PolicyDeniedError(
+                    "A request or token payload is required for policy authorization",
+                    login_type=login_type,
+                )
             payload = await self._auth_required(login_type=login_type, request=request)
         else:
             self._verify_login_type(payload, login_type)
@@ -276,7 +278,7 @@ class AuthManager:
         )
         decision = await self.policy_engine.evaluate(context)
         if not decision.allowed:
-            raise PolicyDeniedError(decision.reason)
+            raise PolicyDeniedError(decision.reason, login_type=login_type)
         return payload
 
     def policy_required(

--- a/authx/policy.py
+++ b/authx/policy.py
@@ -1,0 +1,270 @@
+"""Policy engine primitives for AuthX authorization."""
+
+import inspect
+from collections.abc import Awaitable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal, Optional, Protocol, Union
+
+from fastapi import Request
+
+from authx._internal._scopes import has_required_scopes, match_scope
+from authx.exceptions import PolicyEvaluationError
+from authx.schema import TokenPayload
+
+PolicyEffect = Literal["allow", "deny"]
+PolicySource = Literal["subject", "resource", "environment", "token"]
+PolicyOperator = Literal[
+    "equals",
+    "not_equals",
+    "in",
+    "not_in",
+    "contains",
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "exists",
+]
+
+
+def _read_value(source: Any, key: str) -> Any:
+    """Read a dotted value from mappings or objects."""
+    current = source
+    for part in key.split("."):
+        if current is None:
+            return None
+        if isinstance(current, Mapping):
+            current = current.get(part)
+        else:
+            current = getattr(current, part, None)
+    return current
+
+
+def _as_sequence(value: Any) -> Sequence[Any]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Sequence):
+        return value
+    return [value]
+
+
+@dataclass(frozen=True)
+class PolicyCondition:
+    """A condition evaluated against a policy context source."""
+
+    source: PolicySource
+    key: str
+    operator: PolicyOperator = "equals"
+    value: Any = None
+
+    def matches(self, context: "PolicyContext") -> bool:
+        """Return whether this condition matches the given context."""
+        candidate = _read_value(context.get_source(self.source), self.key)
+
+        if self.operator == "exists":
+            return candidate is not None
+        if self.operator == "equals":
+            return candidate == self.value
+        if self.operator == "not_equals":
+            return candidate != self.value
+        if self.operator == "in":
+            return candidate in _as_sequence(self.value)
+        if self.operator == "not_in":
+            return candidate not in _as_sequence(self.value)
+        if self.operator == "contains":
+            if candidate is None:
+                return False
+            return self.value in candidate
+        if self.operator == "gt":
+            return candidate is not None and candidate > self.value
+        if self.operator == "gte":
+            return candidate is not None and candidate >= self.value
+        if self.operator == "lt":
+            return candidate is not None and candidate < self.value
+        if self.operator == "lte":
+            return candidate is not None and candidate <= self.value
+        raise PolicyEvaluationError(f"Unsupported policy operator: {self.operator}")  # pragma: no cover
+
+
+class PolicyEvaluator(Protocol):
+    """Protocol for custom policy evaluators."""
+
+    def __call__(self, context: "PolicyContext", rule: "PolicyRule") -> Union[bool, Awaitable[bool]]:
+        """Evaluate a policy context and rule."""
+        ...
+
+
+@dataclass(frozen=True)
+class PolicyContext:
+    """Context passed to policy evaluators."""
+
+    login_type: str
+    action: str
+    resource: str
+    payload: Optional[TokenPayload] = None
+    request: Optional[Request] = None
+    subject: Any = None
+    resource_attrs: Any = None
+    environment: Mapping[str, Any] = field(default_factory=dict)
+
+    def get_source(self, source: PolicySource) -> Any:
+        """Return a named source for policy conditions."""
+        if source == "subject":
+            return self.subject
+        if source == "resource":
+            return self.resource_attrs
+        if source == "environment":
+            return self.environment
+        if source == "token" and self.payload is not None:
+            return self.payload.model_dump()
+        if source == "token":
+            return {}
+        raise PolicyEvaluationError(f"Unsupported policy source: {source}")  # pragma: no cover
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    """A single authorization rule."""
+
+    effect: PolicyEffect
+    actions: Sequence[str]
+    resources: Sequence[str]
+    conditions: Sequence[PolicyCondition] = field(default_factory=list)
+    scopes: Optional[Sequence[str]] = None
+    all_scopes_required: bool = True
+    evaluators: Sequence[PolicyEvaluator] = field(default_factory=list)
+    reason: Optional[str] = None
+
+    def matches_action(self, action: str) -> bool:
+        """Return whether the requested action matches this rule."""
+        return any(rule_action == "*" or match_scope(action, rule_action) for rule_action in self.actions)
+
+    def matches_resource(self, resource: str) -> bool:
+        """Return whether the requested resource matches this rule."""
+        return any(rule_resource == "*" or match_scope(resource, rule_resource) for rule_resource in self.resources)
+
+    def matches_scopes(self, payload: Optional[TokenPayload]) -> bool:
+        """Return whether token scopes satisfy this rule."""
+        if self.scopes is None:
+            return True
+        provided = payload.scopes if payload is not None else None
+        return has_required_scopes(self.scopes, provided, all_required=self.all_scopes_required)
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Result of policy evaluation."""
+
+    allowed: bool
+    reason: str
+    rule: Optional[PolicyRule] = None
+
+
+class PolicyEngine:
+    """Evaluate policy rules for AuthX-managed identities."""
+
+    def __init__(
+        self,
+        rules: Optional[Sequence[PolicyRule]] = None,
+        evaluators: Optional[Sequence[PolicyEvaluator]] = None,
+        default_allow: bool = False,
+    ) -> None:
+        """Initialize the policy engine.
+
+        Args:
+            rules: Initial policy rules.
+            evaluators: Global custom evaluators that must pass for matching rules.
+            default_allow: Whether to allow requests when no rule matches.
+        """
+        self._rules = list(rules or [])
+        self._evaluators = list(evaluators or [])
+        self.default_allow = default_allow
+
+    @property
+    def rules(self) -> list[PolicyRule]:
+        """Return registered policy rules."""
+        return list(self._rules)
+
+    def add_rule(self, rule: PolicyRule) -> None:
+        """Register a policy rule."""
+        self._rules.append(rule)
+
+    def add_evaluator(self, evaluator: PolicyEvaluator) -> None:
+        """Register a global custom policy evaluator."""
+        self._evaluators.append(evaluator)
+
+    async def evaluate(self, context: PolicyContext) -> PolicyDecision:
+        """Evaluate context against registered rules.
+
+        Explicit deny rules win over allow rules. If no rule matches, the
+        configured default decision is returned.
+        """
+        allow_decision: Optional[PolicyDecision] = None
+        for rule in self._rules:
+            if not await self._matches_rule(context, rule):
+                continue
+
+            reason = rule.reason or f"Policy rule {rule.effect} matched"
+            decision = PolicyDecision(allowed=(rule.effect == "allow"), reason=reason, rule=rule)
+            if rule.effect == "deny":
+                return decision
+            allow_decision = decision
+
+        if allow_decision is not None:
+            return allow_decision
+
+        if self.default_allow:
+            return PolicyDecision(allowed=True, reason="No policy rule matched; default allow")
+        return PolicyDecision(allowed=False, reason="No policy rule matched")
+
+    async def _matches_rule(self, context: PolicyContext, rule: PolicyRule) -> bool:
+        if not rule.matches_action(context.action):
+            return False
+        if not rule.matches_resource(context.resource):
+            return False
+        if not rule.matches_scopes(context.payload):
+            return False
+        if not all(condition.matches(context) for condition in rule.conditions):
+            return False
+        return await self._run_evaluators(context, rule)
+
+    async def _run_evaluators(self, context: PolicyContext, rule: PolicyRule) -> bool:
+        for evaluator in [*self._evaluators, *rule.evaluators]:
+            result = evaluator(context, rule)
+            if inspect.isawaitable(result):
+                result = await result
+            if not result:
+                return False
+        return True
+
+
+def build_policy_environment(
+    request: Optional[Request] = None,
+    environment: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Build an environment mapping for policy evaluation."""
+    now = datetime.now(timezone.utc)
+    values: dict[str, Any] = {
+        "time": now,
+        "hour": now.hour,
+        "weekday": now.weekday(),
+    }
+    if request is not None:
+        values["method"] = request.method
+        values["path"] = request.url.path
+        values["client_ip"] = request.client.host if request.client is not None else None
+    if environment is not None:
+        values.update(environment)
+    return values
+
+
+def default_subject_from_payload(payload: Optional[TokenPayload]) -> dict[str, Any]:
+    """Build a default subject mapping from token payload claims."""
+    if payload is None:
+        return {}
+    subject = payload.extra_dict.copy()
+    subject["sub"] = payload.sub
+    subject["scopes"] = payload.scopes or []
+    subject["login_type"] = payload.login_type
+    return subject

--- a/authx/schema.py
+++ b/authx/schema.py
@@ -76,6 +76,7 @@ class TokenPayload(BaseModel):
     csrf: Optional[str] = ""
     scopes: Optional[list[str]] = None
     fresh: bool = False
+    login_type: Optional[str] = None
 
     @property
     def _additional_fields(self) -> set[str]:

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -36,6 +36,10 @@ Raised when no CSRF token can be parsed from request.
 
 Raised when token type is invalid.
 
+::: authx.exceptions.LoginTypeMismatchError
+
+Raised when a token belongs to a different login type than the protected endpoint expects.
+
 ::: authx.exceptions.RevokedTokenError
 
 Raised when token is invalid.
@@ -55,6 +59,14 @@ Raised when access token is required.
 ::: authx.exceptions.RefreshTokenRequiredError
 
 Raised when refresh token is required.
+
+::: authx.exceptions.PolicyDeniedError
+
+Raised when policy evaluation denies access.
+
+::: authx.exceptions.PolicyEvaluationError
+
+Raised when a policy evaluator cannot be evaluated.
 
 ::: authx.exceptions.InvalidToken
 

--- a/docs/api/manager.md
+++ b/docs/api/manager.md
@@ -1,0 +1,3 @@
+# AuthManager
+
+::: authx.manager.AuthManager

--- a/docs/api/policy.md
+++ b/docs/api/policy.md
@@ -1,0 +1,23 @@
+# PolicyEngine
+
+::: authx.policy.PolicyEngine
+
+# PolicyRule
+
+::: authx.policy.PolicyRule
+
+# PolicyContext
+
+::: authx.policy.PolicyContext
+
+# PolicyDecision
+
+::: authx.policy.PolicyDecision
+
+# PolicyEvaluator
+
+::: authx.policy.PolicyEvaluator
+
+# PolicyCondition
+
+::: authx.policy.PolicyCondition

--- a/docs/get-started/auth-manager.md
+++ b/docs/get-started/auth-manager.md
@@ -1,0 +1,98 @@
+# AuthManager and Policies
+
+`AuthManager` lets one FastAPI app use multiple isolated `AuthX` instances. Each instance has its own `login_type`, JWT secret, token lifetime, token locations, and optional policy rules.
+
+Use it when your application has fundamentally different identities such as admins, regular users, API clients, or service accounts.
+
+## Multiple Login Types
+
+```python
+from fastapi import Depends, FastAPI
+from authx import AuthManager, AuthX, AuthXConfig
+
+app = FastAPI()
+
+admin_auth = AuthX(
+    config=AuthXConfig(
+        JWT_SECRET_KEY="admin-secret-key",
+        JWT_ACCESS_TOKEN_EXPIRES=3600,
+        JWT_TOKEN_LOCATION=["headers"],
+    ),
+    login_type="admin",
+)
+user_auth = AuthX(
+    config=AuthXConfig(
+        JWT_SECRET_KEY="user-secret-key",
+        JWT_ACCESS_TOKEN_EXPIRES=900,
+        JWT_TOKEN_LOCATION=["headers", "cookies"],
+    ),
+    login_type="user",
+)
+
+manager = AuthManager()
+manager.register(admin_auth)
+manager.register(user_auth)
+manager.handle_errors(app)
+
+
+@app.post("/admin/login")
+def admin_login(username: str):
+    token = manager.create_access_token("admin", uid=username)
+    return {"access_token": token, "login_type": "admin"}
+
+
+@app.get("/admin/dashboard", dependencies=[Depends(manager.access_token_required("admin"))])
+def admin_dashboard():
+    return {"message": "Welcome Admin"}
+```
+
+Tokens created by a managed `AuthX` instance include a `login_type` claim automatically. A token from another registered login type is rejected with `LoginTypeMismatchError`.
+
+## Policy Rules
+
+Policies can combine scopes, subject attributes, resource attributes, environment data, and custom Python evaluators.
+
+```python
+from authx import PolicyCondition, PolicyRule
+
+manager.add_policy_rule(
+    PolicyRule(
+        effect="allow",
+        actions=["users:ban"],
+        resources=["users"],
+        scopes=["admin:*"],
+        conditions=[
+            PolicyCondition(source="environment", key="method", value="POST"),
+        ],
+    )
+)
+
+
+@app.post("/admin/users/{user_id}/ban")
+def ban_user(payload=Depends(manager.policy_required("admin", "users:ban", "users"))):
+    return {"banned_by": payload.sub}
+```
+
+Explicit deny rules win over allow rules. If no rule matches, access is denied by default.
+
+## Custom Evaluators
+
+```python
+from authx import PolicyContext, PolicyRule
+
+
+def active_account_only(context: PolicyContext, rule: PolicyRule) -> bool:
+    return context.subject.get("account_status") == "active"
+
+
+manager.add_policy_rule(
+    PolicyRule(
+        effect="allow",
+        actions=["billing:read"],
+        resources=["billing"],
+        evaluators=[active_account_only],
+    )
+)
+```
+
+For single-type applications, the existing `AuthX` API remains unchanged. `AuthManager` is opt-in.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,6 +204,7 @@ nav:
     - Payload Data: get-started/payload.md
     - JWT Locations: get-started/location.md
     - Scope Management: get-started/scopes.md
+    - AuthManager and Policies: get-started/auth-manager.md
     - Refreshing Tokens: get-started/refresh.md
     - Token Pairs: get-started/token-pair.md
     - Freshness Tokens: get-started/token.md
@@ -229,6 +230,8 @@ nav:
   - Reference - API:
     - api/reference.md
     - api/main.md
+    - api/policy.md
+    - api/manager.md
     - api/config.md
     - api/request.md
     - api/token.md

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -79,6 +79,9 @@ def test_handle_app_errors(app: FastAPI, authx: AuthX):
     assert exc.AccessTokenRequiredError in app.exception_handlers
     assert exc.RefreshTokenRequiredError in app.exception_handlers
     assert exc.CSRFError in app.exception_handlers
+    assert exc.LoginTypeMismatchError in app.exception_handlers
+    assert exc.PolicyDeniedError in app.exception_handlers
+    assert exc.PolicyEvaluationError in app.exception_handlers
 
 
 def test_invalid_token_init():
@@ -185,3 +188,22 @@ async def test_missing_csrf_token_error_shows_detailed_message(app, client, erro
     assert response_json["message"] == detailed_message
     assert "set_access_cookies" in response_json["message"]
     assert "JWT_COOKIE_CSRF_PROTECT=False" in response_json["message"]
+
+
+@pytest.mark.asyncio
+async def test_login_type_mismatch_error_response_has_context(app, client, error_handler):
+    @app.get("/login-type-error")
+    async def login_type_error_route():
+        raise exc.LoginTypeMismatchError(expected_type="admin", actual_type="user")
+
+    error_handler._set_app_exception_handler(app, exc.LoginTypeMismatchError, 401, None)
+
+    response = client.get("/login-type-error")
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "message": "Token type mismatch: expected 'admin', got 'user'",
+        "error_type": "LoginTypeMismatchError",
+        "expected_type": "admin",
+        "actual_type": "user",
+    }

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,108 @@
+"""Tests for AuthManager."""
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from authx import AuthManager, AuthX, AuthXConfig
+from authx.exceptions import BadConfigurationError
+
+
+def make_auth(login_type: str, secret: str) -> AuthX:
+    """Create a login-type aware AuthX instance."""
+    return AuthX(
+        config=AuthXConfig(
+            JWT_SECRET_KEY=secret,
+            JWT_TOKEN_LOCATION=["headers"],
+        ),
+        login_type=login_type,
+    )
+
+
+def test_register_requires_login_type():
+    manager = AuthManager()
+    auth = AuthX(config=AuthXConfig(JWT_SECRET_KEY="secret"))
+
+    try:
+        manager.register(auth)
+    except BadConfigurationError as exc:
+        assert "login_type" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected BadConfigurationError")
+
+
+def test_register_rejects_duplicate_login_type():
+    manager = AuthManager()
+    manager.register(make_auth("admin", "admin-secret"))
+
+    try:
+        manager.register(make_auth("admin", "other-secret"))
+    except BadConfigurationError as exc:
+        assert "already registered" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("Expected BadConfigurationError")
+
+
+def test_create_access_token_uses_registered_context():
+    manager = AuthManager()
+    admin_auth = make_auth("admin", "admin-secret")
+    user_auth = make_auth("user", "user-secret")
+    manager.register(admin_auth)
+    manager.register(user_auth)
+
+    token = manager.create_access_token("admin", uid="root")
+    payload = admin_auth._decode_token(token)
+
+    assert payload.sub == "root"
+    assert payload.login_type == "admin"
+
+
+def test_create_token_pair_includes_login_type():
+    manager = AuthManager()
+    auth = make_auth("service", "service-secret")
+    manager.register(auth)
+
+    tokens = manager.create_token_pair("service", uid="svc")
+
+    assert auth._decode_token(tokens.access_token).login_type == "service"
+    assert auth._decode_token(tokens.refresh_token).login_type == "service"
+
+
+def test_access_dependency_accepts_matching_login_type():
+    manager = AuthManager()
+    admin_auth = make_auth("admin", "admin-secret")
+    manager.register(admin_auth)
+    app = FastAPI()
+    manager.handle_errors(app)
+
+    @app.get("/admin", dependencies=[Depends(manager.access_token_required("admin"))])
+    def admin_route():
+        return {"ok": True}
+
+    token = manager.create_access_token("admin", uid="root")
+    response = TestClient(app).get("/admin", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_access_dependency_rejects_cross_type_token_with_mismatch_error():
+    manager = AuthManager()
+    manager.register(make_auth("admin", "admin-secret"))
+    manager.register(make_auth("user", "user-secret"))
+    app = FastAPI()
+    manager.handle_errors(app)
+
+    @app.get("/admin", dependencies=[Depends(manager.access_token_required("admin"))])
+    def admin_route():
+        return {"ok": True}
+
+    token = manager.create_access_token("user", uid="alice")
+    response = TestClient(app).get("/admin", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "message": "Token type mismatch: expected 'admin', got 'user'",
+        "error_type": "LoginTypeMismatchError",
+        "expected_type": "admin",
+        "actual_type": "user",
+    }

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,165 @@
+"""Tests for policy engine authorization."""
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from authx import AuthManager, AuthX, AuthXConfig
+from authx.policy import PolicyCondition, PolicyContext, PolicyEngine, PolicyRule
+
+
+def make_manager_with_auth(*rules: PolicyRule) -> tuple[AuthManager, AuthX]:
+    """Create a manager with a single admin AuthX instance."""
+    manager = AuthManager(policy_rules=list(rules))
+    auth = AuthX(
+        config=AuthXConfig(
+            JWT_SECRET_KEY="admin-secret",
+            JWT_TOKEN_LOCATION=["headers"],
+        ),
+        login_type="admin",
+    )
+    manager.register(auth)
+    return manager, auth
+
+
+@pytest.mark.asyncio
+async def test_policy_allows_matching_action_resource_and_scope():
+    engine = PolicyEngine(
+        rules=[
+            PolicyRule(
+                effect="allow",
+                actions=["users:ban"],
+                resources=["users"],
+                scopes=["admin:users:ban"],
+            )
+        ]
+    )
+    manager, _ = make_manager_with_auth()
+    token = manager.create_access_token("admin", uid="root", scopes=["admin:*"])
+    payload = manager.get("admin")._decode_token(token)
+
+    decision = await engine.evaluate(
+        PolicyContext(
+            login_type="admin",
+            action="users:ban",
+            resource="users",
+            payload=payload,
+        )
+    )
+
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_policy_deny_rule_wins_over_allow_rule():
+    engine = PolicyEngine(
+        rules=[
+            PolicyRule(effect="allow", actions=["users:*"], resources=["users"]),
+            PolicyRule(effect="deny", actions=["users:delete"], resources=["users"], reason="delete disabled"),
+        ]
+    )
+    decision = await engine.evaluate(PolicyContext(login_type="admin", action="users:delete", resource="users"))
+
+    assert decision.allowed is False
+    assert decision.reason == "delete disabled"
+
+
+@pytest.mark.asyncio
+async def test_policy_subject_resource_and_environment_conditions():
+    engine = PolicyEngine(
+        rules=[
+            PolicyRule(
+                effect="allow",
+                actions=["documents:read"],
+                resources=["documents"],
+                conditions=[
+                    PolicyCondition(source="subject", key="tenant_id", value="tenant-a"),
+                    PolicyCondition(source="resource", key="tenant_id", value="tenant-a"),
+                    PolicyCondition(source="environment", key="method", value="GET"),
+                ],
+            )
+        ]
+    )
+    context = PolicyContext(
+        login_type="user",
+        action="documents:read",
+        resource="documents",
+        subject={"tenant_id": "tenant-a"},
+        resource_attrs={"tenant_id": "tenant-a"},
+        environment={"method": "GET"},
+    )
+
+    decision = await engine.evaluate(context)
+
+    assert decision.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_policy_custom_callable_evaluator():
+    def evaluator(context: PolicyContext, rule: PolicyRule) -> bool:
+        return context.subject["account_status"] == "active"
+
+    engine = PolicyEngine(
+        rules=[
+            PolicyRule(
+                effect="allow",
+                actions=["billing:read"],
+                resources=["billing"],
+                evaluators=[evaluator],
+            )
+        ]
+    )
+
+    allowed = await engine.evaluate(
+        PolicyContext(
+            login_type="user",
+            action="billing:read",
+            resource="billing",
+            subject={"account_status": "active"},
+        )
+    )
+    denied = await engine.evaluate(
+        PolicyContext(
+            login_type="user",
+            action="billing:read",
+            resource="billing",
+            subject={"account_status": "suspended"},
+        )
+    )
+
+    assert allowed.allowed is True
+    assert denied.allowed is False
+
+
+def test_policy_required_dependency_denies_without_matching_policy():
+    manager, _ = make_manager_with_auth()
+    app = FastAPI()
+    manager.handle_errors(app)
+
+    @app.get("/admin/users", dependencies=[Depends(manager.policy_required("admin", "users:ban", "users"))])
+    def route():
+        return {"ok": True}
+
+    token = manager.create_access_token("admin", uid="root")
+    response = TestClient(app).get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 403
+    assert response.json()["error_type"] == "PolicyDeniedError"
+
+
+def test_policy_required_dependency_allows_matching_policy():
+    manager, _ = make_manager_with_auth(
+        PolicyRule(effect="allow", actions=["users:ban"], resources=["users"], scopes=["admin:*"])
+    )
+    app = FastAPI()
+    manager.handle_errors(app)
+
+    @app.get("/admin/users", dependencies=[Depends(manager.policy_required("admin", "users:ban", "users"))])
+    def route():
+        return {"ok": True}
+
+    token = manager.create_access_token("admin", uid="root", scopes=["admin:*"])
+    response = TestClient(app).get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}


### PR DESCRIPTION
Add `login_type` attribute to `AuthXException` and all its subclasses,
so that FastAPI exception handlers can differentiate errors by user type
(e.g., admin vs user token failures) and return type-specific responses.

Changes:
- `AuthXException.__init__` already accepted `login_type` parameter, but
  no raise site passed it; now all occurrences set it correctly.
- Explicitly set `login_type` for `RevokedTokenError`, `MissingTokenError`,
  `InsufficientScopeError` in `AuthX` methods (`_auth_required`,
  websocket handler, `scopes_required`).
- Set `login_type` for `LoginTypeMismatchError` and `PolicyDeniedError`
  in `AuthManager` (`decode_token`, `_verify_login_type`, `authorize`).
- Wrap `AuthX._decode_token()` and `verify_token()` with an outer
  `except AuthXException` to inject `self.login_type` on exceptions from
  `schema.py` / `token.py`.
- Make `AuthManager` inherit from `_ErrorHandler` so that it can directly
  use `self.handle_errors()`; add missing import `Any` in `exceptions.py`.

Why: This allows FastAPI users to write a global exception handler like:

```python
@app.exception_handler(AuthXException)
async def authx_exception_handler(request, exc):
    # Different treatments are applied depending on the type.
    if exc.login_type == "admin":
        return JSONResponse({"error": "Admin auth failed"}, status=401)
    return JSONResponse({"error": "User auth failed"}, status=401)